### PR TITLE
Fixes from this mornings convo

### DIFF
--- a/Nippardation/Exercise/ActiveExerciseDetailView.swift
+++ b/Nippardation/Exercise/ActiveExerciseDetailView.swift
@@ -20,6 +20,7 @@ struct ActiveExerciseDetailView: View {
     @State private var selectedSetIndex: Int?
     @State private var editingReps: Int = 0
     @State private var editingWeight: Double = 0.0
+    @State private var editingSetType: SetType = .working
     @State private var showingCancelAlert = false
     
     let exerciseIndex: Int
@@ -176,6 +177,7 @@ struct ActiveExerciseDetailView: View {
                                                     selectedSetIndex = index
                                                     editingReps = set.reps
                                                     editingWeight = set.weight
+                                                    editingSetType = set.setType
                                                     isEditingSet = true
                                                 } label: {
                                                     Label("Edit", systemImage: "pencil")
@@ -296,8 +298,9 @@ struct ActiveExerciseDetailView: View {
                 EditSetView(
                     reps: $editingReps,
                     weight: $editingWeight,
-                    onSave: { newReps, newWeight in
-                        viewModel.updateSet(at: index, reps: newReps, weight: newWeight)
+                    setType: $editingSetType,
+                    onSave: { newReps, newWeight, newSetType in
+                        viewModel.updateSet(at: index, reps: newReps, weight: newWeight, setType: newSetType)
                         // Update the binding to ensure changes propagate
                         workout.trackedExercises[exerciseIndex] = viewModel.currentExercise
                     }

--- a/Nippardation/Exercise/ActiveExerciseViewModel.swift
+++ b/Nippardation/Exercise/ActiveExerciseViewModel.swift
@@ -172,16 +172,17 @@ class ActiveExerciseViewModel: ObservableObject {
     }
     
     // Update a set at the specified index
-    func updateSet(at index: Int, reps: Int, weight: Double) {
+    func updateSet(at index: Int, reps: Int, weight: Double, setType: SetType) {
         guard index < workout.trackedExercises[exerciseIndex].trackedSets.count else { return }
         
         var updatedSet = workout.trackedExercises[exerciseIndex].trackedSets[index]
         updatedSet.reps = reps
         updatedSet.weight = weight
+        updatedSet.setType = setType
         workout.trackedExercises[exerciseIndex].trackedSets[index] = updatedSet
         
         // Update in WorkoutManager
-        workoutManager.updateSet(exerciseIndex: exerciseIndex, setIndex: index, reps: reps, weight: weight)
+        workoutManager.updateSet(exerciseIndex: exerciseIndex, setIndex: index, reps: reps, weight: weight, setType: setType)
         
         // Recalculate stats
         updateStats()

--- a/Nippardation/Exercise/AddRepCountView.swift
+++ b/Nippardation/Exercise/AddRepCountView.swift
@@ -42,101 +42,23 @@ struct AddRepCountView: View {
     
     var body: some View {
         VStack {
-            HStack {
-                Spacer()
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .resizable()
-                        .frame(width: 32, height: 32)
-                        .aspectRatio(contentMode: .fit)
-                        .foregroundStyle(Color(uiColor: .systemGray))
-                }
-            }
-            .padding()
+            xButton
+                .padding()
             
             Text("Track Set")
                 .font(.title)
                 .fontWeight(.bold)
             
             // Reps section
-            VStack(alignment: .center, spacing: 10) {
-                Text("REPS")
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-                
-                Text("\(reps)")
-                    .font(.system(size: 80, weight: .bold))
-                
-                // Stepper for reps
-                HStack(spacing: 24) {
-                    Button {
-                        if reps > 1 {
-                            reps -= 1
-                        }
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .resizable()
-                            .frame(width: 44, height: 44)
-                            .foregroundColor(Color.appTheme)
-                    }
-                    
-                    Button {
-                        reps += 1
-                    } label: {
-                        Image(systemName: "plus.circle.fill")
-                            .resizable()
-                            .frame(width: 44, height: 44)
-                            .foregroundColor(Color.appTheme)
-                    }
-                }
-                .padding(.vertical, 5)
-            }
-            .padding()
+            repsSection
+                .padding()
             
             // Set type selector
-            Picker("Set Type", selection: $setType) {
-                Text("Warm-up").tag(SetType.warmup)
-                Text("Working").tag(SetType.working)
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal)
-            .onChange(of: setType) { oldValue, newValue in
-                // Update weight based on set type
-                if newValue == .warmup && lastWarmupWeight > 0 {
-                    weight = lastWarmupWeight
-                    weightString = String(format: "%.1f", weight)
-                } else if newValue == .working && lastWorkingWeight > 0 {
-                    weight = lastWorkingWeight
-                    weightString = String(format: "%.1f", weight)
-                }
-            }
+            repTypePicker
             
             // Weight section
-            VStack(alignment: .center, spacing: 10) {
-                Text("WEIGHT (LBS)")
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-                
-                Button {
-                    showWeightPicker = true
-                } label: {
-                    HStack {
-                        Text("\(weight, specifier: "%.1f")")
-                            .font(.system(size: 44, weight: .bold))
-                            .foregroundColor(.primary)
-                        
-                        Image(systemName: "chevron.right")
-                            .foregroundColor(.gray)
-                    }
-                    .padding()
-                    .background(Color(.secondarySystemBackground))
-                    .cornerRadius(12)
-                    .frame(maxWidth: .infinity)
-                }
-            }
-            .padding(.horizontal)
+            weightSelector
+                .padding(.horizontal)
             
             Spacer()
             
@@ -147,32 +69,130 @@ struct AddRepCountView: View {
                 .padding(.bottom, 5)
             
             // Save button
-            Button {
-                // Save the weight for this exercise and set type
-                if setType == .working {
-                    lastWorkingWeight = weight
-                } else {
-                    lastWarmupWeight = weight
-                }
-                
-                // Create tracked set and save
-                let trackedSet = TrackedSet(reps: reps, weight: weight, setType: setType, exerciseType: exercise.type)
-                onSave(trackedSet)
-                dismiss()
-            } label: {
-                Text("Save Set")
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 50)
-                    .background(Color.appTheme)
-                    .cornerRadius(16)
-                    .padding(.vertical)
-            }
-            .padding(.horizontal)
+            saveButton
         }
         .sheet(isPresented: $showWeightPicker) {
             WeightInputView(weight: $weight, weightString: $weightString)
                 .presentationDetents([.fraction(0.667)])
+        }
+    }
+    
+    private var repsSection: some View {
+        VStack(alignment: .center, spacing: 10) {
+            Text("REPS")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            
+            Text("\(reps)")
+                .font(.system(size: 80, weight: .bold))
+            
+            // Stepper for reps
+            HStack(spacing: 24) {
+                Button {
+                    if reps > 1 {
+                        reps -= 1
+                    }
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .resizable()
+                        .frame(width: 44, height: 44)
+                        .foregroundColor(Color.appTheme)
+                }
+                
+                Button {
+                    reps += 1
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .resizable()
+                        .frame(width: 44, height: 44)
+                        .foregroundColor(Color.appTheme)
+                }
+            }
+            .padding(.vertical, 5)
+        }
+    }
+    
+    private var repTypePicker: some View {
+        Picker("Set Type", selection: $setType) {
+            Text("Warm-up").tag(SetType.warmup)
+            Text("Working").tag(SetType.working)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+        .onChange(of: setType) { oldValue, newValue in
+            // Update weight based on set type
+            if newValue == .warmup && lastWarmupWeight > 0 {
+                weight = lastWarmupWeight
+                weightString = String(format: "%.1f", weight)
+            } else if newValue == .working && lastWorkingWeight > 0 {
+                weight = lastWorkingWeight
+                weightString = String(format: "%.1f", weight)
+            }
+        }
+    }
+    
+    private var weightSelector: some View {
+        VStack(alignment: .center, spacing: 10) {
+            Text("WEIGHT (LBS)")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            
+            Button {
+                showWeightPicker = true
+            } label: {
+                HStack {
+                    Text("\(weight, specifier: "%.1f")")
+                        .font(.system(size: 44, weight: .bold))
+                        .foregroundColor(.primary)
+                    
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.gray)
+                }
+                .padding()
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(12)
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+    
+    private var saveButton: some View {
+        Button {
+            // Save the weight for this exercise and set type
+            if setType == .working {
+                lastWorkingWeight = weight
+            } else {
+                lastWarmupWeight = weight
+            }
+            
+            // Create tracked set and save
+            let trackedSet = TrackedSet(reps: reps, weight: weight, setType: setType, exerciseType: exercise.type)
+            onSave(trackedSet)
+            dismiss()
+        } label: {
+            Text("Save Set")
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(Color.appTheme)
+                .cornerRadius(16)
+                .padding(.vertical)
+        }
+        .padding(.horizontal)
+    }
+    
+    private var xButton: some View {
+        HStack {
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .resizable()
+                    .frame(width: 32, height: 32)
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundStyle(Color(uiColor: .systemGray))
+            }
         }
     }
 }

--- a/Nippardation/Exercise/BottomSheetModifier.swift
+++ b/Nippardation/Exercise/BottomSheetModifier.swift
@@ -14,7 +14,7 @@ struct ExpandablePlayerModifier<ExpandedContent: View, CollapsedContent: View>: 
     let expandedContent: ExpandedContent
     let collapsedContent: CollapsedContent
     
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded: Bool = true
     @State private var dragOffset: CGFloat = 0
     
     // Animation settings

--- a/Nippardation/Exercise/EditSetView.swift
+++ b/Nippardation/Exercise/EditSetView.swift
@@ -12,14 +12,16 @@ struct EditSetView: View {
     @Environment(\.dismiss) var dismiss
     @Binding var reps: Int
     @Binding var weight: Double
-    var onSave: (Int, Double) -> Void
+    @Binding var setType: SetType
+    var onSave: (Int, Double, SetType) -> Void
     
     @State private var weightString: String = ""
     @State private var showingWeightPicker = false
     
-    init(reps: Binding<Int>, weight: Binding<Double>, onSave: @escaping (Int, Double) -> Void) {
+    init(reps: Binding<Int>, weight: Binding<Double>, setType: Binding<SetType>, onSave: @escaping (Int, Double, SetType) -> Void) {
         self._reps = reps
         self._weight = weight
+        self._setType = setType
         self.onSave = onSave
         self._weightString = State(initialValue: String(format: "%.1f", weight.wrappedValue))
     }
@@ -72,6 +74,13 @@ struct EditSetView: View {
                 }
                 .padding(.horizontal)
                 
+                Picker("Set Type", selection: $setType) {
+                    Text("Warm-up").tag(SetType.warmup)
+                    Text("Working").tag(SetType.working)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
                 // Weight section
                 VStack(alignment: .leading, spacing: 8) {
                     Text("WEIGHT (LBS)")
@@ -102,7 +111,7 @@ struct EditSetView: View {
                 
                 // Save button
                 Button {
-                    onSave(reps, weight)
+                    onSave(reps, weight, setType)
                     dismiss()
                 } label: {
                     Text("Save Changes")
@@ -118,7 +127,7 @@ struct EditSetView: View {
             .navigationBarItems(
                 leading: Button("Cancel") { dismiss() },
                 trailing: Button("Save") {
-                    onSave(reps, weight)
+                    onSave(reps, weight, setType)
                     dismiss()
                 }
             )
@@ -131,7 +140,7 @@ struct EditSetView: View {
 }
 
 #Preview {
-    EditSetView(reps: .constant(8), weight: .constant(42.5)) { _, _ in
+    EditSetView(reps: .constant(8), weight: .constant(42.5), setType: .constant(.working)) { _, _,_  in
         
     }
 }

--- a/Nippardation/Exercise/WorkoutCacheManager.swift
+++ b/Nippardation/Exercise/WorkoutCacheManager.swift
@@ -72,7 +72,7 @@ class WorkoutCacheManager {
         saveWorkoutCache()
     }
     
-    func updateSet(exerciseIndex: Int, setIndex: Int, reps: Int, weight: Double) {
+    func updateSet(exerciseIndex: Int, setIndex: Int, reps: Int, weight: Double, setType: SetType) {
         guard var workout = activeWorkout,
               exerciseIndex < workout.trackedExercises.count,
               setIndex < workout.trackedExercises[exerciseIndex].trackedSets.count else { return }
@@ -80,6 +80,7 @@ class WorkoutCacheManager {
         var updatedSet = workout.trackedExercises[exerciseIndex].trackedSets[setIndex]
         updatedSet.reps = reps
         updatedSet.weight = weight
+        updatedSet.setType = setType
         
         workout.trackedExercises[exerciseIndex].trackedSets[setIndex] = updatedSet
         activeWorkout = workout

--- a/Nippardation/Exercise/WorkoutManager.swift
+++ b/Nippardation/Exercise/WorkoutManager.swift
@@ -70,8 +70,8 @@ class WorkoutManager: ObservableObject {
         }
     }
     
-    func updateSet(exerciseIndex: Int, setIndex: Int, reps: Int, weight: Double) {
-        cacheManager.updateSet(exerciseIndex: exerciseIndex, setIndex: setIndex, reps: reps, weight: weight)
+    func updateSet(exerciseIndex: Int, setIndex: Int, reps: Int, weight: Double, setType: SetType) {
+        cacheManager.updateSet(exerciseIndex: exerciseIndex, setIndex: setIndex, reps: reps, weight: weight, setType: setType)
     }
     
     func removeTrackedSet(exerciseIndex: Int, setIndex: Int) {


### PR DESCRIPTION
New Movement collapsible view presents as expanded by default.

Set rep counts, weight and set types should persist now.

Moved SetType segmentedControl down in a more obvious position on AddRepCountView