### PR TITLE
Agent C: Implement native video player with caching

### DIFF
--- a/MovementInfoView.swift
+++ b/MovementInfoView.swift
@@ -10,7 +10,14 @@ import SwiftUI
 struct MovementInfoView: View {
     @EnvironmentObject var viewModel: ActiveExerciseViewModel
     var exercise: Exercise
-    
+
+    /// Optional native video URL for R2-hosted MP4 videos
+    /// When provided, displays native AVPlayer instead of WebView
+    var nativeVideoUrl: URL?
+
+    /// Optional exercise server ID for video caching
+    var exerciseServerId: String?
+
     var body: some View {
         Group {
             // Target information
@@ -24,33 +31,47 @@ struct MovementInfoView: View {
             .background(Color(.secondarySystemBackground))
             .cornerRadius(12)
             .padding(.horizontal)
-            
-            // Example video
+
+            // Video section - only show if native video URL is available
+            videoSection
+        }
+    }
+
+    // MARK: - Video Section
+
+    @ViewBuilder
+    private var videoSection: some View {
+        if let videoUrl = nativeVideoUrl {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Example")
                     .font(.headline)
                     .padding(.horizontal)
-                
-                if let webView = viewModel.webView {
-                    WebViewRepresentable(webView: webView)
-                        .aspectRatio(1.8, contentMode: .fit)
-                        .cornerRadius(12)
-                        .frame(height: 200)
-                        .padding(.horizontal)
-                }
+
+                NativeVideoPlayer(
+                    exerciseServerId: exerciseServerId ?? exercise.type.name,
+                    videoUrl: videoUrl,
+                    aspectRatio: 16/9,
+                    showControls: true
+                )
+                .frame(height: 220)
+                .padding(.horizontal)
             }
         }
+        // When no native video URL is available, gracefully degrade by showing nothing
+        // This replaces the old WebView-based YouTube player
     }
-    
+
+    // MARK: - Helper Views
+
     @ViewBuilder
     private func targetInfoRow(title: String, value: String) -> some View {
         HStack {
             Text(title)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
-            
+
             Spacer()
-            
+
             Text(value)
                 .font(.subheadline)
                 .fontWeight(.medium)

--- a/Nippardation/Exercise/ActiveExerciseDetailView.swift
+++ b/Nippardation/Exercise/ActiveExerciseDetailView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import WebKit
 
 struct ActiveExerciseDetailView: View {
     @StateObject private var viewModel: ActiveExerciseViewModel
@@ -74,7 +73,11 @@ struct ActiveExerciseDetailView: View {
                     
                     // Exercise Information
                     if let exercise = viewModel.matchingExercise {
-                        MovementInfoView(exercise: exercise)
+                        MovementInfoView(
+                            exercise: exercise,
+                            nativeVideoUrl: viewModel.nativeVideoUrl,
+                            exerciseServerId: viewModel.exerciseServerId
+                        )
                     } else if isReadOnly {
                         // Fallback for read-only mode when no matching exercise found
                         Text("Exercise details not available")

--- a/Nippardation/Exercise/ActiveExerciseViewModel.swift
+++ b/Nippardation/Exercise/ActiveExerciseViewModel.swift
@@ -60,7 +60,6 @@ class ActiveExerciseViewModel: ObservableObject {
     var nativeVideoUrl: URL? {
         // Currently returns nil as exercise templates use YouTube embeds
         // When ExerciseLibraryItem data is integrated, this will return the R2 URL
-        // Example: URL(string: "https://pub-bd9be4594e0b4c538a1e72055ea5b6fc.r2.dev/exercises/bench-press.mp4")
         return nil
     }
 

--- a/Nippardation/Exercise/ActiveExerciseViewModel.swift
+++ b/Nippardation/Exercise/ActiveExerciseViewModel.swift
@@ -6,52 +6,45 @@
 //
 
 import SwiftUI
-import WebKit
 import Combine
 
 class ActiveExerciseViewModel: ObservableObject {
     // Data
     @Published var workout: TrackedWorkout
     @Published var matchingExercise: Exercise?
-    @Published var webView: WKWebView?
-    
+
     // Stats
     @Published var totalVolume: Double = 0
     @Published var totalReps: Int = 0
-    
+
     // Exercise details
     let exerciseIndex: Int
-    
+
     // Dependencies
     private let workoutManager = WorkoutManager.shared
     private var cancellables = Set<AnyCancellable>()
-    
+
     init(workout: TrackedWorkout, exerciseIndex: Int) {
         self.workout = workout
         self.exerciseIndex = exerciseIndex
-        
+
         // Find matching exercise template
         findMatchingExercise()
-        
-        // Setup WebView if we have a matching exercise
-        if let exercise = matchingExercise {
-            setupWebView(with: exercise.example)
-        }
-        
+
         // Calculate initial stats
         updateStats()
     }
-    
+
     func updateWorkout(_ newWorkout: TrackedWorkout) {
         self.workout = newWorkout
         updateStats()
     }
-    
+
     // Find the matching exercise from the workout templates
     private func findMatchingExercise() {
         let exerciseName = workout.trackedExercises[exerciseIndex].exerciseName
         let allWorkouts = [upperStrength, lowerStrength, pullDay, pushDay, legDay]
-        
+
         for template in allWorkouts {
             if let match = template.exercises.first(where: { $0.type.name == exerciseName }) {
                 self.matchingExercise = match
@@ -59,163 +52,83 @@ class ActiveExerciseViewModel: ObservableObject {
             }
         }
     }
-    
-    // Setup and configure WebView
-    private func setupWebView(with embedString: String) {
-        let config = WKWebViewConfiguration()
-        config.allowsInlineMediaPlayback = true
-        config.mediaTypesRequiringUserActionForPlayback = []
-        let webView = WKWebView(frame: .zero, configuration: config)
-        
-        loadEmbeddedContent(embedString: embedString, webView: webView)
-        self.webView = webView
-    }
-    
-    // Load embedded content into WebView
-    private func loadEmbeddedContent(embedString: String, webView: WKWebView) {
-        // Check if this is just a YouTube ID
-        if embedString.range(of: "<iframe") == nil && embedString.range(of: "http") == nil {
-            // Treat as a YouTube video ID
-            let videoID = embedString.trimmingCharacters(in: .whitespacesAndNewlines)
-            let htmlString = createYouTubeEmbedHTML(videoID: videoID)
-            webView.loadHTMLString(htmlString, baseURL: nil)
-        }
-        // Check if this is a full URL
-        else if embedString.starts(with: "http") {
-            if let videoID = extractYouTubeID(from: embedString) {
-                // It's a YouTube URL
-                let htmlString = createYouTubeEmbedHTML(videoID: videoID)
-                webView.loadHTMLString(htmlString, baseURL: nil)
-            } else {
-                // Try to load as a generic URL
-                if let url = URL(string: embedString) {
-                    webView.load(URLRequest(url: url))
-                }
-            }
-        }
-        // Handle full embed code (iframe)
-        else {
-            let htmlString = """
-                <html>
-                <head>
-                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                    <style>
-                        body { margin: 0; padding: 0; }
-                        .video-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; }
-                        .video-container iframe, .video-container object, .video-container embed {
-                            position: absolute; top: 0; left: 0; width: 100%; height: 100%;
-                        }
-                    </style>
-                </head>
-                <body>
-                    <div class="video-container">
-                        \(embedString)
-                    </div>
-                </body>
-                </html>
-                """
-            webView.loadHTMLString(htmlString, baseURL: nil)
-        }
-    }
-    
-    // Create standard YouTube embed HTML
-    private func createYouTubeEmbedHTML(videoID: String) -> String {
-        return """
-            <html>
-            <head>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <style>
-                    body { margin: 0; padding: 0; }
-                    .video-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; }
-                    .video-container iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
-                </style>
-            </head>
-            <body>
-                <div class="video-container">
-                    <iframe src="https://www.youtube.com/embed/\(videoID)?playsinline=1" frameborder="0" allowfullscreen></iframe>
-                </div>
-            </body>
-            </html>
-            """
-    }
-    
-    // Extract YouTube video ID from URL
-    private func extractYouTubeID(from urlString: String) -> String? {
-        guard let url = URL(string: urlString) else { return nil }
-        
-        // Handle youtube.com/watch?v= format
-        if url.host?.contains("youtube.com") == true,
-           let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
-           let videoID = queryItems.first(where: { $0.name == "v" })?.value {
-            return videoID
-        }
-        
-        // Handle youtu.be/videoID format
-        if url.host == "youtu.be" {
-            return url.lastPathComponent
-        }
-        
+
+    // MARK: - Video URL Properties
+
+    /// Returns the native video URL if available for the current exercise
+    /// This will be populated when ExerciseLibraryItem data with R2 URLs is available
+    var nativeVideoUrl: URL? {
+        // Currently returns nil as exercise templates use YouTube embeds
+        // When ExerciseLibraryItem data is integrated, this will return the R2 URL
+        // Example: URL(string: "https://pub-bd9be4594e0b4c538a1e72055ea5b6fc.r2.dev/exercises/bench-press.mp4")
         return nil
     }
-    
+
+    /// Returns the exercise server ID for video caching
+    /// Uses the exercise name as a fallback identifier
+    var exerciseServerId: String? {
+        // When ExerciseLibraryItem data is integrated, this will return the actual server ID
+        return matchingExercise?.type.name
+    }
+
     // MARK: - Set Management
-    
+
     // Add a set to the current exercise
     func addSet(_ set: TrackedSet) {
         workout.trackedExercises[exerciseIndex].trackedSets.append(set)
-        
+
         // Update in WorkoutManager
         workoutManager.updateTrackedSet(exerciseIndex: exerciseIndex, set: set)
-        
+
         // Recalculate stats
         updateStats()
     }
-    
+
     // Update a set at the specified index
     func updateSet(at index: Int, reps: Int, weight: Double, setType: SetType) {
         guard index < workout.trackedExercises[exerciseIndex].trackedSets.count else { return }
-        
+
         var updatedSet = workout.trackedExercises[exerciseIndex].trackedSets[index]
         updatedSet.reps = reps
         updatedSet.weight = weight
         updatedSet.setType = setType
         workout.trackedExercises[exerciseIndex].trackedSets[index] = updatedSet
-        
+
         // Update in WorkoutManager
         workoutManager.updateSet(exerciseIndex: exerciseIndex, setIndex: index, reps: reps, weight: weight, setType: setType)
-        
+
         // Recalculate stats
         updateStats()
     }
-    
+
     // Delete a set at the specified index
     func deleteSet(at index: Int) {
         guard index < workout.trackedExercises[exerciseIndex].trackedSets.count else { return }
-        
+
         workout.trackedExercises[exerciseIndex].trackedSets.remove(at: index)
-        
+
         // Update in WorkoutManager
         workoutManager.removeTrackedSet(exerciseIndex: exerciseIndex, setIndex: index)
-        
+
         // Recalculate stats
         updateStats()
     }
-    
+
     // MARK: - Stats
-    
+
     // Update workout statistics
     private func updateStats() {
         let sets = workout.trackedExercises[exerciseIndex].trackedSets
-        
+
         // Calculate total volume
         totalVolume = sets.reduce(0.0) { sum, set in
             sum + (Double(set.reps) * set.weight)
         }
-        
+
         // Calculate total reps
         totalReps = sets.reduce(0) { $0 + $1.reps }
     }
-    
+
     // Get current tracked exercise
     var currentExercise: TrackedExercise {
         return workout.trackedExercises[exerciseIndex]

--- a/Nippardation/NippardationApp.swift
+++ b/Nippardation/NippardationApp.swift
@@ -17,6 +17,9 @@ struct NippardationApp: App {
     init() {
         StringArrayTransformer.register()
         configureFirebase()
+
+        // Configure dependency container with real implementations
+        DependencyContainer.shared.configureForProduction()
     }
     
     private func configureFirebase() {

--- a/Nippardation/Services/DependencyContainer.swift
+++ b/Nippardation/Services/DependencyContainer.swift
@@ -114,6 +114,9 @@ final class DependencyContainer: ObservableObject {
     /// Configures the container with production services
     /// Called during app initialization
     func configureForProduction() {
+        // Register real video cache service
+        self.videoCacheService = VideoCacheService()
+
         // TODO: Replace with real implementations when available
         // self.exerciseRepository = ExerciseRepository()
         // self.templateRepository = TemplateRepository()

--- a/Nippardation/Services/VideoCache/VideoCacheService.swift
+++ b/Nippardation/Services/VideoCache/VideoCacheService.swift
@@ -1,0 +1,368 @@
+//
+//  VideoCacheService.swift
+//  Nippardation
+//
+//  Concrete implementation of VideoCacheServiceProtocol
+//  Manages local video caching with LRU eviction
+//
+
+import Foundation
+import Combine
+
+/// Concrete implementation of VideoCacheServiceProtocol
+/// Manages local video caching with LRU eviction
+@MainActor
+final class VideoCacheService: VideoCacheServiceProtocol {
+
+    // MARK: - Constants
+
+    /// Maximum cache size in bytes (500 MB)
+    private let _maxCacheSize: Int64 = 500 * 1024 * 1024
+
+    /// Cache directory name
+    private let cacheDirectoryName = "VideoCache"
+
+    // MARK: - Dependencies
+
+    private let downloadManager: VideoDownloadManager
+    private let fileManager: FileManager
+    private let templateRepository: any TemplateRepositoryProtocol
+    private let programRepository: any ProgramRepositoryProtocol
+
+    // MARK: - State
+
+    private let _downloadProgress = PassthroughSubject<VideoDownloadProgress, Never>()
+
+    /// In-memory index of cached videos
+    private var cacheIndex: [String: CacheEntry] = [:]
+
+    private struct CacheEntry: Codable {
+        let exerciseServerId: String
+        let localPath: String
+        let fileSize: Int64
+        var lastAccessedAt: Date
+    }
+
+    // MARK: - Protocol Properties
+
+    var downloadProgressPublisher: AnyPublisher<VideoDownloadProgress, Never> {
+        _downloadProgress.eraseToAnyPublisher()
+    }
+
+    var totalCacheSize: Int64 {
+        cacheIndex.values.reduce(0) { $0 + $1.fileSize }
+    }
+
+    var maxCacheSize: Int64 {
+        _maxCacheSize
+    }
+
+    // MARK: - Computed Properties
+
+    private var cacheDirectory: URL {
+        let cachesDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return cachesDir.appendingPathComponent(cacheDirectoryName)
+    }
+
+    private var cacheIndexURL: URL {
+        cacheDirectory.appendingPathComponent("cache_index.json")
+    }
+
+    // MARK: - Initialization
+
+    init(
+        downloadManager: VideoDownloadManager = VideoDownloadManager(),
+        fileManager: FileManager = .default,
+        templateRepository: (any TemplateRepositoryProtocol)? = nil,
+        programRepository: (any ProgramRepositoryProtocol)? = nil
+    ) {
+        self.downloadManager = downloadManager
+        self.fileManager = fileManager
+        self.templateRepository = templateRepository ?? DependencyContainer.shared.templateRepository
+        self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+
+        // Ensure cache directory exists
+        createCacheDirectoryIfNeeded()
+
+        // Load cache index from disk
+        loadCacheIndex()
+
+        // Set up download progress forwarding
+        Task {
+            await downloadManager.setProgressHandler { [weak self] progress in
+                Task { @MainActor [weak self] in
+                    self?._downloadProgress.send(progress)
+                }
+            }
+        }
+    }
+
+    // MARK: - Cache Operations
+
+    func getCachedVideoURL(for exerciseServerId: String) -> URL? {
+        guard let entry = cacheIndex[exerciseServerId] else {
+            return nil
+        }
+
+        // Verify file exists
+        if fileManager.fileExists(atPath: entry.localPath) {
+            return URL(fileURLWithPath: entry.localPath)
+        } else {
+            // File was deleted externally, remove from index
+            cacheIndex.removeValue(forKey: exerciseServerId)
+            saveCacheIndex()
+            return nil
+        }
+    }
+
+    func isVideoCached(for exerciseServerId: String) -> Bool {
+        guard let entry = cacheIndex[exerciseServerId] else {
+            return false
+        }
+        return fileManager.fileExists(atPath: entry.localPath)
+    }
+
+    func cacheVideo(for exerciseServerId: String, from remoteURL: URL) async throws -> URL {
+        // Check if already cached
+        if let localURL = getCachedVideoURL(for: exerciseServerId) {
+            await touchVideo(for: exerciseServerId)
+            return localURL
+        }
+
+        // Determine local URL
+        let localURL = localURLFor(exerciseServerId: exerciseServerId)
+
+        // Download the video
+        let resultURL = try await downloadManager.download(
+            exerciseServerId: exerciseServerId,
+            remoteURL: remoteURL,
+            localURL: localURL
+        )
+
+        // Get file size and add to cache index
+        if let fileSize = fileSizeAt(resultURL) {
+            cacheIndex[exerciseServerId] = CacheEntry(
+                exerciseServerId: exerciseServerId,
+                localPath: resultURL.path,
+                fileSize: fileSize,
+                lastAccessedAt: Date()
+            )
+            saveCacheIndex()
+
+            // Check if we need to evict
+            try await evictIfNeeded()
+        }
+
+        return resultURL
+    }
+
+    func removeCachedVideo(for exerciseServerId: String) async throws {
+        guard let entry = cacheIndex[exerciseServerId] else {
+            return
+        }
+
+        // Remove file
+        let url = URL(fileURLWithPath: entry.localPath)
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+
+        // Remove from index
+        cacheIndex.removeValue(forKey: exerciseServerId)
+        saveCacheIndex()
+    }
+
+    func clearCache() async throws {
+        // Cancel any active downloads
+        await downloadManager.cancelAll()
+
+        // Clear the index
+        cacheIndex.removeAll()
+
+        // Delete all files in cache directory
+        if fileManager.fileExists(atPath: cacheDirectory.path) {
+            let contents = try fileManager.contentsOfDirectory(
+                at: cacheDirectory,
+                includingPropertiesForKeys: nil
+            )
+            for url in contents {
+                try fileManager.removeItem(at: url)
+            }
+        }
+
+        // Save empty index
+        saveCacheIndex()
+    }
+
+    // MARK: - Prefetching
+
+    func prefetchVideos(for templateServerId: String) async {
+        let task = Task {
+            do {
+                // Get template from repository
+                let template = try await templateRepository.fetchTemplate(serverId: templateServerId)
+
+                // Download videos for each exercise that has a video URL
+                for templateExercise in template.exercises {
+                    // Check for cancellation
+                    if Task.isCancelled { break }
+
+                    // Get exercise details - use exerciseServerId as cache key
+                    if let exerciseItem = templateExercise.exerciseLibraryItem,
+                       let videoUrl = exerciseItem.videoUrl,
+                       !isVideoCached(for: templateExercise.exerciseServerId) {
+                        _ = try? await cacheVideo(for: templateExercise.exerciseServerId, from: videoUrl)
+                    }
+                }
+            } catch {
+                // Silently fail prefetch - it's an optimization
+            }
+        }
+
+        await downloadManager.setPrefetchTask(task)
+        await task.value
+    }
+
+    func prefetchVideosForActiveProgram() async {
+        let task = Task {
+            do {
+                // Get active program
+                guard let activeProgram = try await programRepository.getActiveProgram() else {
+                    return
+                }
+
+                // Prefetch videos for each workout's template in the program
+                for programWorkout in activeProgram.workouts {
+                    if Task.isCancelled { break }
+
+                    // Fetch the template if not already resolved
+                    let template: Template
+                    if let resolvedTemplate = programWorkout.template {
+                        template = resolvedTemplate
+                    } else {
+                        template = try await templateRepository.fetchTemplate(serverId: programWorkout.templateServerId)
+                    }
+
+                    // Download videos for each exercise
+                    for templateExercise in template.exercises {
+                        if Task.isCancelled { break }
+
+                        if let exerciseItem = templateExercise.exerciseLibraryItem,
+                           let videoUrl = exerciseItem.videoUrl,
+                           !isVideoCached(for: templateExercise.exerciseServerId) {
+                            _ = try? await cacheVideo(for: templateExercise.exerciseServerId, from: videoUrl)
+                        }
+                    }
+                }
+            } catch {
+                // Silently fail prefetch
+            }
+        }
+
+        await downloadManager.setPrefetchTask(task)
+        await task.value
+    }
+
+    func cancelPrefetch() {
+        Task {
+            await downloadManager.cancelPrefetch()
+        }
+    }
+
+    // MARK: - Cache Management
+
+    func evictIfNeeded() async throws {
+        guard totalCacheSize > _maxCacheSize else { return }
+
+        // Target 80% of max size
+        let targetSize = Int64(Double(_maxCacheSize) * 0.8)
+        try await evictToSize(targetSize)
+    }
+
+    func getCacheStats() -> VideoCacheStats {
+        let sortedEntries = cacheIndex.values.sorted { $0.lastAccessedAt < $1.lastAccessedAt }
+
+        return VideoCacheStats(
+            totalSize: totalCacheSize,
+            maxSize: _maxCacheSize,
+            videoCount: cacheIndex.count,
+            oldestAccessDate: sortedEntries.first?.lastAccessedAt,
+            newestAccessDate: sortedEntries.last?.lastAccessedAt
+        )
+    }
+
+    func touchVideo(for exerciseServerId: String) async {
+        guard cacheIndex[exerciseServerId] != nil else { return }
+        cacheIndex[exerciseServerId]?.lastAccessedAt = Date()
+        saveCacheIndex()
+    }
+
+    // MARK: - Private Helpers
+
+    private func localURLFor(exerciseServerId: String) -> URL {
+        // Sanitize the serverId for use as a filename
+        let sanitized = exerciseServerId.replacingOccurrences(of: "/", with: "_")
+        return cacheDirectory.appendingPathComponent("\(sanitized).mp4")
+    }
+
+    private func createCacheDirectoryIfNeeded() {
+        if !fileManager.fileExists(atPath: cacheDirectory.path) {
+            try? fileManager.createDirectory(
+                at: cacheDirectory,
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    private func fileSizeAt(_ url: URL) -> Int64? {
+        guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+              let size = attrs[.size] as? Int64 else {
+            return nil
+        }
+        return size
+    }
+
+    private func evictToSize(_ targetBytes: Int64) async throws {
+        // Sort by last accessed (oldest first) for LRU eviction
+        var entries = cacheIndex.values.sorted { $0.lastAccessedAt < $1.lastAccessedAt }
+        var currentSize = totalCacheSize
+
+        // Remove oldest entries until under target
+        while currentSize > targetBytes && !entries.isEmpty {
+            let oldest = entries.removeFirst()
+
+            // Delete file
+            let url = URL(fileURLWithPath: oldest.localPath)
+            try? fileManager.removeItem(at: url)
+
+            // Update index
+            cacheIndex.removeValue(forKey: oldest.exerciseServerId)
+            currentSize -= oldest.fileSize
+        }
+
+        saveCacheIndex()
+    }
+
+    // MARK: - Persistence
+
+    private func loadCacheIndex() {
+        guard fileManager.fileExists(atPath: cacheIndexURL.path),
+              let data = try? Data(contentsOf: cacheIndexURL),
+              let savedEntries = try? JSONDecoder().decode([CacheEntry].self, from: data) else {
+            return
+        }
+
+        // Verify files exist before adding to index
+        for entry in savedEntries {
+            if fileManager.fileExists(atPath: entry.localPath) {
+                cacheIndex[entry.exerciseServerId] = entry
+            }
+        }
+    }
+
+    private func saveCacheIndex() {
+        let entries = Array(cacheIndex.values)
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        try? data.write(to: cacheIndexURL)
+    }
+}

--- a/Nippardation/Services/VideoCache/VideoCacheService.swift
+++ b/Nippardation/Services/VideoCache/VideoCacheService.swift
@@ -316,10 +316,10 @@ final class VideoCacheService: VideoCacheServiceProtocol {
 
     private func fileSizeAt(_ url: URL) -> Int64? {
         guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? Int64 else {
+              let size = attrs[.size] as? NSNumber else {
             return nil
         }
-        return size
+        return size.int64Value
     }
 
     private func evictToSize(_ targetBytes: Int64) async throws {

--- a/Nippardation/Services/VideoCache/VideoDownloadManager.swift
+++ b/Nippardation/Services/VideoCache/VideoDownloadManager.swift
@@ -23,6 +23,7 @@ actor VideoDownloadManager {
     // MARK: - State
 
     private var activeDownloads: [String: ActiveDownload] = [:]
+    private var activeSessions: [String: URLSession] = [:] // Track sessions for cancellation
     private var progressHandler: ((VideoDownloadProgress) -> Void)?
     private var prefetchTask: Task<Void, Never>?
 
@@ -85,7 +86,13 @@ actor VideoDownloadManager {
                 delegateQueue: nil
             )
 
-            defer { session.finishTasksAndInvalidate() }
+            // Track session for potential cancellation
+            activeSessions[exerciseServerId] = session
+
+            defer {
+                activeSessions.removeValue(forKey: exerciseServerId)
+                session.finishTasksAndInvalidate()
+            }
 
             // Report downloading state
             reportProgress(exerciseServerId: exerciseServerId, state: .downloading, bytesDownloaded: 0, totalBytes: 0)
@@ -131,14 +138,23 @@ actor VideoDownloadManager {
         prefetchTask?.cancel()
         prefetchTask = nil
 
-        for exerciseServerId in activeDownloads.keys {
+        // Cancel all active URLSessions
+        for (exerciseServerId, session) in activeSessions {
+            session.invalidateAndCancel()
             reportProgress(exerciseServerId: exerciseServerId, state: .cancelled, bytesDownloaded: 0, totalBytes: 0)
         }
+        activeSessions.removeAll()
         activeDownloads.removeAll()
     }
 
     /// Cancel download for specific exercise
     func cancel(exerciseServerId: String) {
+        // Cancel the URLSession if it exists
+        if let session = activeSessions[exerciseServerId] {
+            session.invalidateAndCancel()
+            activeSessions.removeValue(forKey: exerciseServerId)
+        }
+
         if activeDownloads[exerciseServerId] != nil {
             reportProgress(exerciseServerId: exerciseServerId, state: .cancelled, bytesDownloaded: 0, totalBytes: 0)
             activeDownloads.removeValue(forKey: exerciseServerId)

--- a/Nippardation/Services/VideoCache/VideoDownloadManager.swift
+++ b/Nippardation/Services/VideoCache/VideoDownloadManager.swift
@@ -114,7 +114,7 @@ actor VideoDownloadManager {
             try await moveToFinalLocation(from: tempURL, to: localURL)
 
             // Get file size for final progress report
-            let fileSize = try FileManager.default.attributesOfItem(atPath: localURL.path)[.size] as? Int64 ?? 0
+            let fileSize = (try FileManager.default.attributesOfItem(atPath: localURL.path)[.size] as? NSNumber)?.int64Value ?? 0
 
             // Report completion
             reportProgress(exerciseServerId: exerciseServerId, state: .completed, bytesDownloaded: fileSize, totalBytes: fileSize)

--- a/Nippardation/Services/VideoCache/VideoDownloadManager.swift
+++ b/Nippardation/Services/VideoCache/VideoDownloadManager.swift
@@ -1,0 +1,256 @@
+//
+//  VideoDownloadManager.swift
+//  Nippardation
+//
+//  Manages video file downloads with progress tracking
+//
+
+import Foundation
+
+/// Manages video file downloads with progress tracking
+actor VideoDownloadManager {
+
+    // MARK: - Types
+
+    struct ActiveDownload {
+        let exerciseServerId: String
+        let remoteURL: URL
+        let localURL: URL
+        var bytesDownloaded: Int64 = 0
+        var totalBytes: Int64 = 0
+    }
+
+    // MARK: - State
+
+    private var activeDownloads: [String: ActiveDownload] = [:]
+    private var progressHandler: ((VideoDownloadProgress) -> Void)?
+    private var prefetchTask: Task<Void, Never>?
+
+    // MARK: - Configuration
+
+    func setProgressHandler(_ handler: @escaping (VideoDownloadProgress) -> Void) {
+        self.progressHandler = handler
+    }
+
+    // MARK: - Download Operations
+
+    /// Download a video file with progress tracking
+    /// - Parameters:
+    ///   - exerciseServerId: Server ID of the exercise (used as cache key)
+    ///   - remoteURL: Remote video URL
+    ///   - localURL: Local destination URL
+    /// - Returns: Local file URL after download completes
+    func download(
+        exerciseServerId: String,
+        remoteURL: URL,
+        localURL: URL
+    ) async throws -> URL {
+        // Check if already downloading
+        if activeDownloads[exerciseServerId] != nil {
+            return try await waitForExistingDownload(exerciseServerId: exerciseServerId, localURL: localURL)
+        }
+
+        // Track this download
+        activeDownloads[exerciseServerId] = ActiveDownload(
+            exerciseServerId: exerciseServerId,
+            remoteURL: remoteURL,
+            localURL: localURL
+        )
+
+        // Report queued state
+        reportProgress(exerciseServerId: exerciseServerId, state: .queued, bytesDownloaded: 0, totalBytes: 0)
+
+        defer {
+            activeDownloads.removeValue(forKey: exerciseServerId)
+        }
+
+        do {
+            // Create delegate for progress tracking
+            let delegate = DownloadProgressDelegate(
+                exerciseServerId: exerciseServerId,
+                progressHandler: { [weak self] serverId, bytesDownloaded, totalBytes in
+                    Task { [weak self] in
+                        await self?.updateProgress(
+                            exerciseServerId: serverId,
+                            bytesDownloaded: bytesDownloaded,
+                            totalBytes: totalBytes
+                        )
+                    }
+                }
+            )
+
+            let session = URLSession(
+                configuration: .default,
+                delegate: delegate,
+                delegateQueue: nil
+            )
+
+            defer { session.finishTasksAndInvalidate() }
+
+            // Report downloading state
+            reportProgress(exerciseServerId: exerciseServerId, state: .downloading, bytesDownloaded: 0, totalBytes: 0)
+
+            // Perform download
+            let (tempURL, response) = try await session.download(from: remoteURL, delegate: delegate)
+
+            // Validate response
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                throw VideoCacheError.downloadFailed(
+                    remoteURL,
+                    NSError(domain: "HTTP", code: statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(statusCode)"])
+                )
+            }
+
+            // Move to final location
+            try await moveToFinalLocation(from: tempURL, to: localURL)
+
+            // Get file size for final progress report
+            let fileSize = try FileManager.default.attributesOfItem(atPath: localURL.path)[.size] as? Int64 ?? 0
+
+            // Report completion
+            reportProgress(exerciseServerId: exerciseServerId, state: .completed, bytesDownloaded: fileSize, totalBytes: fileSize)
+
+            return localURL
+
+        } catch {
+            // Report failure
+            reportProgress(
+                exerciseServerId: exerciseServerId,
+                state: .failed(error.localizedDescription),
+                bytesDownloaded: 0,
+                totalBytes: 0
+            )
+            throw error
+        }
+    }
+
+    /// Cancel all active downloads
+    func cancelAll() {
+        prefetchTask?.cancel()
+        prefetchTask = nil
+
+        for exerciseServerId in activeDownloads.keys {
+            reportProgress(exerciseServerId: exerciseServerId, state: .cancelled, bytesDownloaded: 0, totalBytes: 0)
+        }
+        activeDownloads.removeAll()
+    }
+
+    /// Cancel download for specific exercise
+    func cancel(exerciseServerId: String) {
+        if activeDownloads[exerciseServerId] != nil {
+            reportProgress(exerciseServerId: exerciseServerId, state: .cancelled, bytesDownloaded: 0, totalBytes: 0)
+            activeDownloads.removeValue(forKey: exerciseServerId)
+        }
+    }
+
+    /// Check if a download is in progress
+    func isDownloading(exerciseServerId: String) -> Bool {
+        return activeDownloads[exerciseServerId] != nil
+    }
+
+    // MARK: - Prefetch Support
+
+    /// Set the prefetch task for cancellation tracking
+    func setPrefetchTask(_ task: Task<Void, Never>) {
+        prefetchTask = task
+    }
+
+    /// Cancel prefetch operations
+    func cancelPrefetch() {
+        prefetchTask?.cancel()
+        prefetchTask = nil
+    }
+
+    // MARK: - Private Helpers
+
+    private func waitForExistingDownload(exerciseServerId: String, localURL: URL) async throws -> URL {
+        // Poll until download completes
+        while activeDownloads[exerciseServerId] != nil {
+            try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        }
+
+        // Check if file exists
+        if FileManager.default.fileExists(atPath: localURL.path) {
+            return localURL
+        } else {
+            throw VideoCacheError.downloadFailed(
+                localURL,
+                NSError(domain: "Download", code: -1, userInfo: [NSLocalizedDescriptionKey: "Download was cancelled or failed"])
+            )
+        }
+    }
+
+    private func updateProgress(exerciseServerId: String, bytesDownloaded: Int64, totalBytes: Int64) {
+        activeDownloads[exerciseServerId]?.bytesDownloaded = bytesDownloaded
+        activeDownloads[exerciseServerId]?.totalBytes = totalBytes
+        reportProgress(
+            exerciseServerId: exerciseServerId,
+            state: .downloading,
+            bytesDownloaded: bytesDownloaded,
+            totalBytes: totalBytes
+        )
+    }
+
+    private func reportProgress(exerciseServerId: String, state: VideoDownloadProgress.DownloadState, bytesDownloaded: Int64, totalBytes: Int64) {
+        let progress = VideoDownloadProgress(
+            exerciseServerId: exerciseServerId,
+            state: state,
+            bytesDownloaded: bytesDownloaded,
+            totalBytes: totalBytes
+        )
+        progressHandler?(progress)
+    }
+
+    private func moveToFinalLocation(from tempURL: URL, to localURL: URL) async throws {
+        let fileManager = FileManager.default
+
+        // Create directory if needed
+        let directory = localURL.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: directory.path) {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        // Remove existing file if present
+        if fileManager.fileExists(atPath: localURL.path) {
+            try fileManager.removeItem(at: localURL)
+        }
+
+        // Move temp file to final location
+        try fileManager.moveItem(at: tempURL, to: localURL)
+    }
+}
+
+// MARK: - Download Progress Delegate
+
+private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
+    let exerciseServerId: String
+    let progressHandler: (String, Int64, Int64) -> Void
+
+    init(
+        exerciseServerId: String,
+        progressHandler: @escaping (String, Int64, Int64) -> Void
+    ) {
+        self.exerciseServerId = exerciseServerId
+        self.progressHandler = progressHandler
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        // File handling is done in the main download method
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        progressHandler(exerciseServerId, totalBytesWritten, totalBytesExpectedToWrite)
+    }
+}

--- a/Nippardation/Views/VideoPlayer/CompactVideoPlayer.swift
+++ b/Nippardation/Views/VideoPlayer/CompactVideoPlayer.swift
@@ -1,0 +1,130 @@
+//
+//  CompactVideoPlayer.swift
+//  Nippardation
+//
+//  Compact video player for use in lists and smaller spaces
+//
+
+import SwiftUI
+
+/// Compact video player for use in lists and smaller spaces
+/// Shows thumbnail with play button, opens full player in sheet
+struct CompactVideoPlayer: View {
+
+    let exerciseServerId: String
+    let videoUrl: URL?
+    let thumbnailUrl: URL?
+
+    @State private var showFullPlayer = false
+
+    var body: some View {
+        ZStack {
+            // Thumbnail or placeholder
+            thumbnailView
+
+            // Play button overlay
+            if videoUrl != nil {
+                Button {
+                    showFullPlayer = true
+                } label: {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 50))
+                        .foregroundColor(.white)
+                        .shadow(radius: 4)
+                }
+            }
+        }
+        .aspectRatio(16/9, contentMode: .fit)
+        .background(Color.black)
+        .cornerRadius(8)
+        .sheet(isPresented: $showFullPlayer) {
+            fullPlayerSheet
+        }
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var thumbnailView: some View {
+        if let thumbnailUrl = thumbnailUrl {
+            AsyncImage(url: thumbnailUrl) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .aspectRatio(16/9, contentMode: .fill)
+                case .failure:
+                    placeholder
+                case .empty:
+                    placeholder
+                        .overlay(
+                            ProgressView()
+                                .tint(.white)
+                        )
+                @unknown default:
+                    placeholder
+                }
+            }
+        } else {
+            placeholder
+        }
+    }
+
+    private var placeholder: some View {
+        Rectangle()
+            .fill(Color.gray.opacity(0.3))
+            .overlay(
+                Image(systemName: "figure.strengthtraining.traditional")
+                    .font(.largeTitle)
+                    .foregroundColor(.gray)
+            )
+    }
+
+    private var fullPlayerSheet: some View {
+        NavigationStack {
+            VStack {
+                Spacer()
+
+                NativeVideoPlayer(
+                    exerciseServerId: exerciseServerId,
+                    videoUrl: videoUrl,
+                    showControls: true
+                )
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .navigationTitle("Exercise Demo")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        showFullPlayer = false
+                    }
+                }
+            }
+            .background(Color.black)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 20) {
+        CompactVideoPlayer(
+            exerciseServerId: "test-exercise",
+            videoUrl: URL(string: "https://pub-bd9be4594e0b4c538a1e72055ea5b6fc.r2.dev/exercises/bench-press.mp4"),
+            thumbnailUrl: nil
+        )
+        .frame(width: 200)
+
+        CompactVideoPlayer(
+            exerciseServerId: "no-video",
+            videoUrl: nil,
+            thumbnailUrl: nil
+        )
+        .frame(width: 200)
+    }
+    .padding()
+}

--- a/Nippardation/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Nippardation/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -64,9 +64,18 @@ struct NativeVideoPlayer: View {
         .task {
             await viewModel.loadVideo(exerciseServerId: exerciseServerId, videoUrl: videoUrl)
         }
-        .onChange(of: exerciseServerId) { _, newId in
+        .onChange(of: exerciseServerId) { oldId, newId in
+            // Only reload if the ID actually changed
+            guard oldId != newId else { return }
             Task {
                 await viewModel.loadVideo(exerciseServerId: newId, videoUrl: videoUrl)
+            }
+        }
+        .onChange(of: videoUrl) { oldUrl, newUrl in
+            // Reload if video URL changes (even with same exercise ID)
+            guard oldUrl != newUrl else { return }
+            Task {
+                await viewModel.loadVideo(exerciseServerId: exerciseServerId, videoUrl: newUrl)
             }
         }
         .onDisappear {

--- a/Nippardation/Views/VideoPlayer/NativeVideoPlayer.swift
+++ b/Nippardation/Views/VideoPlayer/NativeVideoPlayer.swift
@@ -1,0 +1,247 @@
+//
+//  NativeVideoPlayer.swift
+//  Nippardation
+//
+//  Native video player view using AVPlayer
+//
+
+import SwiftUI
+import AVFoundation
+import AVKit
+
+/// Native video player view using AVPlayer
+struct NativeVideoPlayer: View {
+
+    // MARK: - Properties
+
+    @StateObject private var viewModel: VideoPlayerViewModel
+
+    let exerciseServerId: String
+    let videoUrl: URL?
+    let aspectRatio: CGFloat
+    let showControls: Bool
+
+    // MARK: - Initialization
+
+    init(
+        exerciseServerId: String,
+        videoUrl: URL?,
+        aspectRatio: CGFloat = 16/9,
+        showControls: Bool = true
+    ) {
+        self.exerciseServerId = exerciseServerId
+        self.videoUrl = videoUrl
+        self.aspectRatio = aspectRatio
+        self.showControls = showControls
+        self._viewModel = StateObject(wrappedValue: VideoPlayerViewModel())
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            // Video layer
+            VideoPlayerLayer(player: viewModel.player)
+                .aspectRatio(aspectRatio, contentMode: .fit)
+                .background(Color.black)
+                .cornerRadius(12)
+
+            // Loading overlay
+            if viewModel.isLoading {
+                loadingOverlay
+            }
+
+            // Error overlay
+            if let error = viewModel.error {
+                errorOverlay(message: error)
+            }
+
+            // Controls overlay
+            if showControls && !viewModel.isLoading && viewModel.error == nil {
+                controlsOverlay
+            }
+        }
+        .task {
+            await viewModel.loadVideo(exerciseServerId: exerciseServerId, videoUrl: videoUrl)
+        }
+        .onChange(of: exerciseServerId) { _, newId in
+            Task {
+                await viewModel.loadVideo(exerciseServerId: newId, videoUrl: videoUrl)
+            }
+        }
+        .onDisappear {
+            viewModel.pause()
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var loadingOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.3)
+
+            VStack(spacing: 12) {
+                if viewModel.downloadProgress > 0 && viewModel.downloadProgress < 1 {
+                    // Download progress
+                    ProgressView(value: viewModel.downloadProgress)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .scaleEffect(1.2)
+
+                    Text("Downloading... \(Int(viewModel.downloadProgress * 100))%")
+                        .font(.caption)
+                        .foregroundColor(.white)
+                } else {
+                    // Indeterminate loading
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .scaleEffect(1.2)
+
+                    Text("Loading video...")
+                        .font(.caption)
+                        .foregroundColor(.white)
+                }
+            }
+        }
+        .cornerRadius(12)
+    }
+
+    private func errorOverlay(message: String) -> some View {
+        ZStack {
+            Color.black.opacity(0.5)
+
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.title)
+                    .foregroundColor(.yellow)
+
+                Text(message)
+                    .font(.caption)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+
+                Button("Retry") {
+                    Task {
+                        await viewModel.loadVideo(exerciseServerId: exerciseServerId, videoUrl: videoUrl)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .tint(.white)
+            }
+            .padding()
+        }
+        .cornerRadius(12)
+    }
+
+    private var controlsOverlay: some View {
+        VStack {
+            Spacer()
+
+            HStack(spacing: 20) {
+                // Play/Pause button
+                Button {
+                    viewModel.togglePlayPause()
+                } label: {
+                    Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.title2)
+                        .foregroundColor(.white)
+                        .frame(width: 44, height: 44)
+                        .background(Color.black.opacity(0.5))
+                        .clipShape(Circle())
+                }
+
+                // Progress bar
+                if viewModel.duration > 0 {
+                    GeometryReader { geometry in
+                        ZStack(alignment: .leading) {
+                            // Background
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(Color.white.opacity(0.3))
+                                .frame(height: 4)
+
+                            // Progress
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(Color.white)
+                                .frame(
+                                    width: max(0, min(geometry.size.width, geometry.size.width * CGFloat(viewModel.currentTime / viewModel.duration))),
+                                    height: 4
+                                )
+                        }
+                        .frame(height: 4)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    }
+                    .frame(height: 20)
+                }
+
+                // Mute button
+                Button {
+                    viewModel.toggleMute()
+                } label: {
+                    Image(systemName: viewModel.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                        .font(.body)
+                        .foregroundColor(.white)
+                        .frame(width: 36, height: 36)
+                        .background(Color.black.opacity(0.5))
+                        .clipShape(Circle())
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: [.clear, .black.opacity(0.6)]),
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+        }
+        .cornerRadius(12)
+    }
+}
+
+// MARK: - Video Player Layer
+
+/// UIViewRepresentable wrapper for AVPlayerLayer
+struct VideoPlayerLayer: UIViewRepresentable {
+    let player: AVPlayer
+
+    func makeUIView(context: Context) -> PlayerUIView {
+        let view = PlayerUIView()
+        view.player = player
+        return view
+    }
+
+    func updateUIView(_ uiView: PlayerUIView, context: Context) {
+        uiView.player = player
+    }
+}
+
+/// UIView that hosts an AVPlayerLayer
+class PlayerUIView: UIView {
+
+    override class var layerClass: AnyClass {
+        AVPlayerLayer.self
+    }
+
+    var playerLayer: AVPlayerLayer {
+        layer as! AVPlayerLayer
+    }
+
+    var player: AVPlayer? {
+        get { playerLayer.player }
+        set {
+            playerLayer.player = newValue
+            playerLayer.videoGravity = .resizeAspect
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NativeVideoPlayer(
+        exerciseServerId: "test-exercise",
+        videoUrl: URL(string: "https://pub-bd9be4594e0b4c538a1e72055ea5b6fc.r2.dev/exercises/bench-press.mp4")
+    )
+    .frame(height: 250)
+    .padding()
+}

--- a/Nippardation/Views/VideoPlayer/VideoPlayerViewModel.swift
+++ b/Nippardation/Views/VideoPlayer/VideoPlayerViewModel.swift
@@ -1,0 +1,251 @@
+//
+//  VideoPlayerViewModel.swift
+//  Nippardation
+//
+//  ViewModel for native video player using AVPlayer
+//
+
+import Foundation
+import AVFoundation
+import Combine
+
+/// ViewModel for native video player
+@MainActor
+final class VideoPlayerViewModel: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published var isLoading = false
+    @Published var isPlaying = false
+    @Published var isMuted = true // Start muted by default for exercise demos
+    @Published var error: String?
+    @Published var currentTime: Double = 0
+    @Published var duration: Double = 0
+    @Published var isLooping = true
+    @Published var downloadProgress: Double = 0
+
+    // MARK: - Player
+
+    let player: AVPlayer
+    private var playerItem: AVPlayerItem?
+    private var timeObserver: Any?
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Dependencies
+
+    private let videoCacheService: any VideoCacheServiceProtocol
+
+    // MARK: - State
+
+    private var currentExerciseServerId: String?
+    private var loadTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+
+    init(videoCacheService: (any VideoCacheServiceProtocol)? = nil) {
+        self.videoCacheService = videoCacheService ?? DependencyContainer.shared.videoCacheService
+        self.player = AVPlayer()
+
+        setupPlayer()
+        observeDownloadProgress()
+    }
+
+    deinit {
+        if let observer = timeObserver {
+            player.removeTimeObserver(observer)
+        }
+        loadTask?.cancel()
+    }
+
+    // MARK: - Public Methods
+
+    /// Load a video for an exercise
+    /// - Parameters:
+    ///   - exerciseServerId: The server ID of the exercise
+    ///   - videoUrl: The remote URL of the video (optional if already cached)
+    func loadVideo(exerciseServerId: String, videoUrl: URL?) async {
+        // Don't reload same video
+        if currentExerciseServerId == exerciseServerId && playerItem != nil {
+            return
+        }
+
+        // Cancel any previous load
+        loadTask?.cancel()
+
+        currentExerciseServerId = exerciseServerId
+        isLoading = true
+        error = nil
+        downloadProgress = 0
+
+        // Check if already cached
+        if let localURL = videoCacheService.getCachedVideoURL(for: exerciseServerId) {
+            setupPlayerItem(with: localURL)
+            isLoading = false
+            await videoCacheService.touchVideo(for: exerciseServerId)
+            return
+        }
+
+        // Need to download - requires video URL
+        guard let remoteURL = videoUrl else {
+            error = "No video URL available"
+            isLoading = false
+            return
+        }
+
+        loadTask = Task {
+            do {
+                let localURL = try await videoCacheService.cacheVideo(
+                    for: exerciseServerId,
+                    from: remoteURL
+                )
+
+                if !Task.isCancelled {
+                    setupPlayerItem(with: localURL)
+                    isLoading = false
+                }
+            } catch {
+                if !Task.isCancelled {
+                    self.error = "Failed to load video"
+                    self.isLoading = false
+                }
+            }
+        }
+    }
+
+    /// Load video directly from a URL (for preview/testing)
+    func loadVideo(from url: URL) {
+        setupPlayerItem(with: url)
+    }
+
+    /// Play the video
+    func play() {
+        player.play()
+        isPlaying = true
+    }
+
+    /// Pause the video
+    func pause() {
+        player.pause()
+        isPlaying = false
+    }
+
+    /// Toggle play/pause state
+    func togglePlayPause() {
+        if isPlaying {
+            pause()
+        } else {
+            play()
+        }
+    }
+
+    /// Toggle mute state
+    func toggleMute() {
+        isMuted.toggle()
+        player.isMuted = isMuted
+    }
+
+    /// Seek to a specific time
+    func seek(to time: Double) {
+        let cmTime = CMTime(seconds: time, preferredTimescale: 600)
+        player.seek(to: cmTime)
+    }
+
+    /// Restart the video from the beginning
+    func restart() {
+        seek(to: 0)
+        play()
+    }
+
+    /// Stop and clean up the player
+    func stop() {
+        loadTask?.cancel()
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        playerItem = nil
+        currentExerciseServerId = nil
+        isPlaying = false
+        currentTime = 0
+        duration = 0
+    }
+
+    // MARK: - Private Methods
+
+    private func setupPlayer() {
+        player.isMuted = isMuted
+
+        // Observe playback state
+        player.publisher(for: \.timeControlStatus)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                self?.isPlaying = status == .playing
+            }
+            .store(in: &cancellables)
+    }
+
+    private func observeDownloadProgress() {
+        videoCacheService.downloadProgressPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] progress in
+                guard let self = self,
+                      progress.exerciseServerId == self.currentExerciseServerId else {
+                    return
+                }
+                self.downloadProgress = progress.fractionComplete
+            }
+            .store(in: &cancellables)
+    }
+
+    private func setupPlayerItem(with url: URL) {
+        // Clean up previous item
+        if let observer = timeObserver {
+            player.removeTimeObserver(observer)
+            timeObserver = nil
+        }
+
+        // Create new player item
+        let item = AVPlayerItem(url: url)
+        playerItem = item
+        player.replaceCurrentItem(with: item)
+
+        // Observe duration
+        item.publisher(for: \.duration)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] duration in
+                if duration.isNumeric {
+                    self?.duration = duration.seconds
+                }
+            }
+            .store(in: &cancellables)
+
+        // Observe status for errors
+        item.publisher(for: \.status)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                if status == .failed {
+                    self?.error = "Failed to play video"
+                }
+            }
+            .store(in: &cancellables)
+
+        // Add time observer
+        timeObserver = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 0.1, preferredTimescale: 600),
+            queue: .main
+        ) { [weak self] time in
+            self?.currentTime = time.seconds
+        }
+
+        // Observe end of playback for looping
+        NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime, object: item)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                if self?.isLooping == true {
+                    self?.restart()
+                }
+            }
+            .store(in: &cancellables)
+
+        // Auto-play
+        play()
+    }
+}

--- a/Nippardation/Views/VideoPlayer/VideoPlayerViewModel.swift
+++ b/Nippardation/Views/VideoPlayer/VideoPlayerViewModel.swift
@@ -30,6 +30,7 @@ final class VideoPlayerViewModel: ObservableObject {
     private var playerItem: AVPlayerItem?
     private var timeObserver: Any?
     private var cancellables = Set<AnyCancellable>()
+    private var playerItemCancellables = Set<AnyCancellable>() // Separate set for player item subscriptions
 
     // MARK: - Dependencies
 
@@ -64,18 +65,22 @@ final class VideoPlayerViewModel: ObservableObject {
     ///   - exerciseServerId: The server ID of the exercise
     ///   - videoUrl: The remote URL of the video (optional if already cached)
     func loadVideo(exerciseServerId: String, videoUrl: URL?) async {
-        // Don't reload same video
-        if currentExerciseServerId == exerciseServerId && playerItem != nil {
+        // Don't reload same video if already loaded successfully
+        if currentExerciseServerId == exerciseServerId && playerItem != nil && error == nil {
             return
         }
 
         // Cancel any previous load
         loadTask?.cancel()
+        loadTask = nil
 
+        // Reset state for new video
         currentExerciseServerId = exerciseServerId
         isLoading = true
         error = nil
         downloadProgress = 0
+        currentTime = 0
+        duration = 0
 
         // Check if already cached
         if let localURL = videoCacheService.getCachedVideoURL(for: exerciseServerId) {
@@ -159,13 +164,20 @@ final class VideoPlayerViewModel: ObservableObject {
     /// Stop and clean up the player
     func stop() {
         loadTask?.cancel()
+        loadTask = nil
         player.pause()
         player.replaceCurrentItem(with: nil)
         playerItem = nil
+        playerItemCancellables.removeAll() // Clean up player item subscriptions
+        if let observer = timeObserver {
+            player.removeTimeObserver(observer)
+            timeObserver = nil
+        }
         currentExerciseServerId = nil
         isPlaying = false
         currentTime = 0
         duration = 0
+        error = nil
     }
 
     // MARK: - Private Methods
@@ -196,7 +208,9 @@ final class VideoPlayerViewModel: ObservableObject {
     }
 
     private func setupPlayerItem(with url: URL) {
-        // Clean up previous item
+        // Clean up previous item's subscriptions to prevent memory leaks
+        playerItemCancellables.removeAll()
+
         if let observer = timeObserver {
             player.removeTimeObserver(observer)
             timeObserver = nil
@@ -207,7 +221,7 @@ final class VideoPlayerViewModel: ObservableObject {
         playerItem = item
         player.replaceCurrentItem(with: item)
 
-        // Observe duration
+        // Observe duration - stored in player item specific set
         item.publisher(for: \.duration)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] duration in
@@ -215,7 +229,7 @@ final class VideoPlayerViewModel: ObservableObject {
                     self?.duration = duration.seconds
                 }
             }
-            .store(in: &cancellables)
+            .store(in: &playerItemCancellables)
 
         // Observe status for errors
         item.publisher(for: \.status)
@@ -225,7 +239,7 @@ final class VideoPlayerViewModel: ObservableObject {
                     self?.error = "Failed to play video"
                 }
             }
-            .store(in: &cancellables)
+            .store(in: &playerItemCancellables)
 
         // Add time observer
         timeObserver = player.addPeriodicTimeObserver(
@@ -243,7 +257,7 @@ final class VideoPlayerViewModel: ObservableObject {
                     self?.restart()
                 }
             }
-            .store(in: &cancellables)
+            .store(in: &playerItemCancellables)
 
         // Auto-play
         play()

--- a/Nippardation/Views/VideoPlayer/VideoPlayerViewModel.swift
+++ b/Nippardation/Views/VideoPlayer/VideoPlayerViewModel.swift
@@ -246,7 +246,9 @@ final class VideoPlayerViewModel: ObservableObject {
             forInterval: CMTime(seconds: 0.1, preferredTimescale: 600),
             queue: .main
         ) { [weak self] time in
-            self?.currentTime = time.seconds
+            Task { @MainActor in
+                self?.currentTime = time.seconds
+            }
         }
 
         // Observe end of playback for looping


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Native video playback with caching**
> 
> - Add `NativeVideoPlayer`, `VideoPlayerViewModel`, and `CompactVideoPlayer` for AVPlayer-based playback with controls, progress, mute, and looping
> - Implement `VideoCacheService` (LRU, 500MB cap) and `VideoDownloadManager` (actor) with progress, cancellation, and prefetch of template/program videos; expose via `DependencyContainer.configureForProduction()`
> - Update `MovementInfoView` to show a native video section when `nativeVideoUrl` exists and remove WebView usage
> - Update `ActiveExerciseDetailView` and `ActiveExerciseViewModel` to pass `nativeVideoUrl` and `exerciseServerId` (stubbed for now)
> - Wire app startup to register the real video cache service
> 
> **Notes**
> 
> - WebKit/WebView-based YouTube player removed in favor of native playback
> - Prefetch and cache stats/touching added; graceful handling for missing URLs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59348bbda9fac0b02692060f070bdb8fd6d518de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->