### PR TITLE
Add design system foundation with tokens, components, and tab config

### DIFF
--- a/Nippardation/DesignSystem/AppDesignSystem.swift
+++ b/Nippardation/DesignSystem/AppDesignSystem.swift
@@ -1,0 +1,213 @@
+//
+//  AppDesignSystem.swift
+//  Nippardation
+//
+//  Centralized design tokens and reusable view modifiers
+//
+
+import SwiftUI
+
+// MARK: - Spacing Scale
+
+enum AppSpacing {
+    static let xxs: CGFloat = 4
+    static let xs: CGFloat = 8
+    static let sm: CGFloat = 12
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 24
+    static let xl: CGFloat = 32
+    static let xxl: CGFloat = 48
+}
+
+// MARK: - Corner Radius Tokens
+
+enum AppCornerRadius {
+    static let small: CGFloat = 8
+    static let medium: CGFloat = 12
+    static let large: CGFloat = 16
+    static let xl: CGFloat = 20
+}
+
+// MARK: - Shadow Presets
+
+struct AppShadow {
+    let color: Color
+    let radius: CGFloat
+    let x: CGFloat
+    let y: CGFloat
+
+    static let card = AppShadow(
+        color: Color.primary.opacity(0.08),
+        radius: 8,
+        x: 0,
+        y: 2
+    )
+
+    static let elevated = AppShadow(
+        color: Color.primary.opacity(0.15),
+        radius: 12,
+        x: 0,
+        y: 4
+    )
+
+    static let floating = AppShadow(
+        color: Color.primary.opacity(0.2),
+        radius: 16,
+        x: 0,
+        y: 6
+    )
+}
+
+// MARK: - Card View Modifier
+
+struct CardModifier: ViewModifier {
+    var cornerRadius: CGFloat = AppCornerRadius.large
+    var shadow: AppShadow = .card
+    var hasBorder: Bool = false
+    var borderColor: Color = Color.primary.opacity(0.1)
+
+    func body(content: Content) -> some View {
+        content
+            .background(Color(.secondarySystemBackground))
+            .cornerRadius(cornerRadius)
+            .shadow(
+                color: shadow.color,
+                radius: shadow.radius,
+                x: shadow.x,
+                y: shadow.y
+            )
+            .overlay(
+                Group {
+                    if hasBorder {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .stroke(borderColor, lineWidth: 1)
+                    }
+                }
+            )
+    }
+}
+
+// MARK: - Dashed Card View Modifier
+
+struct DashedCardModifier: ViewModifier {
+    var cornerRadius: CGFloat = AppCornerRadius.large
+    var dashColor: Color = Color.secondary.opacity(0.4)
+    var lineWidth: CGFloat = 2
+    var dash: [CGFloat] = [8, 6]
+
+    func body(content: Content) -> some View {
+        content
+            .background(Color(.secondarySystemBackground).opacity(0.5))
+            .cornerRadius(cornerRadius)
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(style: StrokeStyle(lineWidth: lineWidth, dash: dash))
+                    .foregroundColor(dashColor)
+            )
+    }
+}
+
+// MARK: - Gradient Card View Modifier
+
+struct GradientCardModifier: ViewModifier {
+    var colors: [Color]
+    var cornerRadius: CGFloat = AppCornerRadius.xl
+    var hasBorder: Bool = true
+    var borderColor: Color = Color.blue.opacity(0.3)
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: colors),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .cornerRadius(cornerRadius)
+            .overlay(
+                Group {
+                    if hasBorder {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .stroke(borderColor, lineWidth: 1)
+                    }
+                }
+            )
+    }
+}
+
+// MARK: - View Extensions
+
+extension View {
+    func cardStyle(
+        cornerRadius: CGFloat = AppCornerRadius.large,
+        shadow: AppShadow = .card,
+        hasBorder: Bool = false,
+        borderColor: Color = Color.primary.opacity(0.1)
+    ) -> some View {
+        modifier(CardModifier(
+            cornerRadius: cornerRadius,
+            shadow: shadow,
+            hasBorder: hasBorder,
+            borderColor: borderColor
+        ))
+    }
+
+    func dashedCardStyle(
+        cornerRadius: CGFloat = AppCornerRadius.large,
+        dashColor: Color = Color.secondary.opacity(0.4)
+    ) -> some View {
+        modifier(DashedCardModifier(
+            cornerRadius: cornerRadius,
+            dashColor: dashColor
+        ))
+    }
+
+    func gradientCardStyle(
+        colors: [Color] = [Color.blue.opacity(0.15), Color.blue.opacity(0.05)],
+        cornerRadius: CGFloat = AppCornerRadius.xl,
+        hasBorder: Bool = true,
+        borderColor: Color = Color.blue.opacity(0.3)
+    ) -> some View {
+        modifier(GradientCardModifier(
+            colors: colors,
+            cornerRadius: cornerRadius,
+            hasBorder: hasBorder,
+            borderColor: borderColor
+        ))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Card Styles") {
+    ScrollView {
+        VStack(spacing: AppSpacing.lg) {
+            Text("Standard Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .cardStyle()
+
+            Text("Card with Border")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .cardStyle(hasBorder: true)
+
+            Text("Elevated Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .cardStyle(shadow: .elevated)
+
+            Text("Dashed Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .dashedCardStyle()
+
+            Text("Gradient Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .gradientCardStyle()
+        }
+        .padding(AppSpacing.md)
+    }
+}

--- a/Nippardation/DesignSystem/ReusableComponents.swift
+++ b/Nippardation/DesignSystem/ReusableComponents.swift
@@ -1,0 +1,220 @@
+//
+//  ReusableComponents.swift
+//  Nippardation
+//
+//  Reusable UI components for the design system
+//
+
+import SwiftUI
+
+// MARK: - Pill Badge
+
+/// Colored pill for status text (Active, Warmup, Compound, etc.)
+struct PillBadge: View {
+    let text: String
+    var color: Color = .blue
+    var style: PillStyle = .filled
+
+    enum PillStyle {
+        case filled
+        case tinted
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, AppSpacing.xs)
+            .padding(.vertical, AppSpacing.xxs)
+            .foregroundColor(foregroundColor)
+            .background(backgroundColor)
+            .cornerRadius(AppCornerRadius.small)
+    }
+
+    private var foregroundColor: Color {
+        switch style {
+        case .filled:
+            return .white
+        case .tinted:
+            return color
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .filled:
+            return color
+        case .tinted:
+            return color.opacity(0.15)
+        }
+    }
+}
+
+// MARK: - Stat Card
+
+/// Metric display card with icon, value, label, and optional trend
+struct StatCard: View {
+    let icon: String
+    let value: String
+    let label: String
+    var trend: StatTrend?
+    var iconColor: Color = .blue
+
+    enum StatTrend {
+        case up(String)
+        case down(String)
+        case neutral(String)
+
+        var text: String {
+            switch self {
+            case .up(let val), .down(let val), .neutral(let val):
+                return val
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .up: return .green
+            case .down: return .red
+            case .neutral: return .secondary
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .up: return "arrow.up.right"
+            case .down: return "arrow.down.right"
+            case .neutral: return "minus"
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundColor(iconColor)
+
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            if let trend {
+                HStack(spacing: AppSpacing.xxs) {
+                    Image(systemName: trend.icon)
+                        .font(.caption2)
+                    Text(trend.text)
+                        .font(.caption2)
+                }
+                .foregroundColor(trend.color)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(AppSpacing.md)
+        .cardStyle()
+    }
+}
+
+// MARK: - Section Header
+
+/// Consistent section header with optional trailing action
+struct SectionHeader: View {
+    let title: String
+    var action: SectionAction?
+
+    struct SectionAction {
+        let label: String
+        let handler: () -> Void
+    }
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.headline)
+
+            Spacer()
+
+            if let action {
+                Button(action: action.handler) {
+                    Text(action.label)
+                        .font(.subheadline)
+                        .foregroundColor(.appTheme)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Icon Circle
+
+/// Colored circle with an SF Symbol icon inside
+struct IconCircle: View {
+    let icon: String
+    var color: Color = .blue
+    var size: CGFloat = 40
+
+    var body: some View {
+        Image(systemName: icon)
+            .font(.system(size: size * 0.4))
+            .foregroundColor(color)
+            .frame(width: size, height: size)
+            .background(color.opacity(0.15))
+            .clipShape(Circle())
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Pill Badges") {
+    HStack(spacing: AppSpacing.xs) {
+        PillBadge(text: "Active", color: .green)
+        PillBadge(text: "Compound", color: .blue, style: .tinted)
+        PillBadge(text: "Warmup", color: .orange, style: .tinted)
+        PillBadge(text: "8 Weeks", color: .purple, style: .tinted)
+    }
+    .padding()
+}
+
+#Preview("Stat Cards") {
+    HStack(spacing: AppSpacing.sm) {
+        StatCard(
+            icon: "flame.fill",
+            value: "4",
+            label: "This Week",
+            trend: .up("+1"),
+            iconColor: .orange
+        )
+        StatCard(
+            icon: "scalemass.fill",
+            value: "12.4K",
+            label: "Volume (lbs)",
+            trend: .up("+8%"),
+            iconColor: .blue
+        )
+    }
+    .padding()
+}
+
+#Preview("Section Header") {
+    VStack(spacing: AppSpacing.lg) {
+        SectionHeader(title: "Recent Workouts")
+        SectionHeader(
+            title: "My Programs",
+            action: .init(label: "See All", handler: {})
+        )
+    }
+    .padding()
+}
+
+#Preview("Icon Circles") {
+    HStack(spacing: AppSpacing.sm) {
+        IconCircle(icon: "dumbbell.fill", color: .blue)
+        IconCircle(icon: "figure.strengthtraining.traditional", color: .green)
+        IconCircle(icon: "heart.fill", color: .red, size: 32)
+    }
+    .padding()
+}

--- a/Nippardation/DesignSystem/TabBarConfiguration.swift
+++ b/Nippardation/DesignSystem/TabBarConfiguration.swift
@@ -1,0 +1,47 @@
+//
+//  TabBarConfiguration.swift
+//  Nippardation
+//
+//  Tab bar configuration for the bottom navigation
+//
+
+import SwiftUI
+
+/// Defines the 5 bottom tabs for the main navigation
+enum AppTab: String, CaseIterable, Hashable {
+    case home
+    case programs
+    case templates
+    case history
+    case profile
+
+    var label: String {
+        switch self {
+        case .home: return "Home"
+        case .programs: return "Programs"
+        case .templates: return "Templates"
+        case .history: return "History"
+        case .profile: return "Profile"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .home: return "house"
+        case .programs: return "list.bullet.clipboard"
+        case .templates: return "doc.text"
+        case .history: return "clock.arrow.circlepath"
+        case .profile: return "person"
+        }
+    }
+
+    var selectedIcon: String {
+        switch self {
+        case .home: return "house.fill"
+        case .programs: return "list.bullet.clipboard.fill"
+        case .templates: return "doc.text.fill"
+        case .history: return "clock.arrow.circlepath"
+        case .profile: return "person.fill"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **AppDesignSystem.swift**: Centralized spacing scale, corner radius tokens, shadow presets, and three ViewModifiers (`CardModifier`, `DashedCardModifier`, `GradientCardModifier`) with convenient View extensions
- **ReusableComponents.swift**: `PillBadge`, `StatCard`, `SectionHeader`, `IconCircle` — reusable components consumed by all subsequent UI revamp PRs
- **TabBarConfiguration.swift**: `AppTab` enum defining 5 bottom tabs (Home, Programs, Templates, History, Profile) with SF Symbol icon names — structure only, no TabView yet

## Context

PR1 of 10 in the UI revamp. Establishes a shared design system foundation so all subsequent PRs use consistent tokens and components rather than scattered inline styling.

## Test plan

- [x] `xcodebuild build` passes — no compile errors
- [x] All existing tests pass (no existing code modified)
- [x] Preview blocks included for visual verification in Xcode Previews
- [x] No user-facing changes — purely additive new types
- [x] 480 lines total (within 1000-line PR limit)