### PR TITLE
Add bottom tab bar navigation and restructure root views

### DIFF
--- a/Nippardation/DesignSystem/AppDesignSystem.swift
+++ b/Nippardation/DesignSystem/AppDesignSystem.swift
@@ -1,0 +1,213 @@
+//
+//  AppDesignSystem.swift
+//  Nippardation
+//
+//  Centralized design tokens and reusable view modifiers
+//
+
+import SwiftUI
+
+// MARK: - Spacing Scale
+
+enum AppSpacing {
+    static let xxs: CGFloat = 4
+    static let xs: CGFloat = 8
+    static let sm: CGFloat = 12
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 24
+    static let xl: CGFloat = 32
+    static let xxl: CGFloat = 48
+}
+
+// MARK: - Corner Radius Tokens
+
+enum AppCornerRadius {
+    static let small: CGFloat = 8
+    static let medium: CGFloat = 12
+    static let large: CGFloat = 16
+    static let xl: CGFloat = 20
+}
+
+// MARK: - Shadow Presets
+
+struct AppShadow {
+    let color: Color
+    let radius: CGFloat
+    let x: CGFloat
+    let y: CGFloat
+
+    static let card = AppShadow(
+        color: Color.primary.opacity(0.08),
+        radius: 8,
+        x: 0,
+        y: 2
+    )
+
+    static let elevated = AppShadow(
+        color: Color.primary.opacity(0.15),
+        radius: 12,
+        x: 0,
+        y: 4
+    )
+
+    static let floating = AppShadow(
+        color: Color.primary.opacity(0.2),
+        radius: 16,
+        x: 0,
+        y: 6
+    )
+}
+
+// MARK: - Card View Modifier
+
+struct CardModifier: ViewModifier {
+    var cornerRadius: CGFloat = AppCornerRadius.large
+    var shadow: AppShadow = .card
+    var hasBorder: Bool = false
+    var borderColor: Color = Color.primary.opacity(0.1)
+
+    func body(content: Content) -> some View {
+        content
+            .background(Color(.secondarySystemBackground))
+            .cornerRadius(cornerRadius)
+            .shadow(
+                color: shadow.color,
+                radius: shadow.radius,
+                x: shadow.x,
+                y: shadow.y
+            )
+            .overlay(
+                Group {
+                    if hasBorder {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .stroke(borderColor, lineWidth: 1)
+                    }
+                }
+            )
+    }
+}
+
+// MARK: - Dashed Card View Modifier
+
+struct DashedCardModifier: ViewModifier {
+    var cornerRadius: CGFloat = AppCornerRadius.large
+    var dashColor: Color = Color.secondary.opacity(0.4)
+    var lineWidth: CGFloat = 2
+    var dash: [CGFloat] = [8, 6]
+
+    func body(content: Content) -> some View {
+        content
+            .background(Color(.secondarySystemBackground).opacity(0.5))
+            .cornerRadius(cornerRadius)
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(style: StrokeStyle(lineWidth: lineWidth, dash: dash))
+                    .foregroundColor(dashColor)
+            )
+    }
+}
+
+// MARK: - Gradient Card View Modifier
+
+struct GradientCardModifier: ViewModifier {
+    var colors: [Color]
+    var cornerRadius: CGFloat = AppCornerRadius.xl
+    var hasBorder: Bool = true
+    var borderColor: Color = Color.blue.opacity(0.3)
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                LinearGradient(
+                    gradient: Gradient(colors: colors),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .cornerRadius(cornerRadius)
+            .overlay(
+                Group {
+                    if hasBorder {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .stroke(borderColor, lineWidth: 1)
+                    }
+                }
+            )
+    }
+}
+
+// MARK: - View Extensions
+
+extension View {
+    func cardStyle(
+        cornerRadius: CGFloat = AppCornerRadius.large,
+        shadow: AppShadow = .card,
+        hasBorder: Bool = false,
+        borderColor: Color = Color.primary.opacity(0.1)
+    ) -> some View {
+        modifier(CardModifier(
+            cornerRadius: cornerRadius,
+            shadow: shadow,
+            hasBorder: hasBorder,
+            borderColor: borderColor
+        ))
+    }
+
+    func dashedCardStyle(
+        cornerRadius: CGFloat = AppCornerRadius.large,
+        dashColor: Color = Color.secondary.opacity(0.4)
+    ) -> some View {
+        modifier(DashedCardModifier(
+            cornerRadius: cornerRadius,
+            dashColor: dashColor
+        ))
+    }
+
+    func gradientCardStyle(
+        colors: [Color] = [Color.blue.opacity(0.15), Color.blue.opacity(0.05)],
+        cornerRadius: CGFloat = AppCornerRadius.xl,
+        hasBorder: Bool = true,
+        borderColor: Color = Color.blue.opacity(0.3)
+    ) -> some View {
+        modifier(GradientCardModifier(
+            colors: colors,
+            cornerRadius: cornerRadius,
+            hasBorder: hasBorder,
+            borderColor: borderColor
+        ))
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Card Styles") {
+    ScrollView {
+        VStack(spacing: AppSpacing.lg) {
+            Text("Standard Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .cardStyle()
+
+            Text("Card with Border")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .cardStyle(hasBorder: true)
+
+            Text("Elevated Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .cardStyle(shadow: .elevated)
+
+            Text("Dashed Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .dashedCardStyle()
+
+            Text("Gradient Card")
+                .frame(maxWidth: .infinity)
+                .padding(AppSpacing.md)
+                .gradientCardStyle()
+        }
+        .padding(AppSpacing.md)
+    }
+}

--- a/Nippardation/DesignSystem/ReusableComponents.swift
+++ b/Nippardation/DesignSystem/ReusableComponents.swift
@@ -1,0 +1,220 @@
+//
+//  ReusableComponents.swift
+//  Nippardation
+//
+//  Reusable UI components for the design system
+//
+
+import SwiftUI
+
+// MARK: - Pill Badge
+
+/// Colored pill for status text (Active, Warmup, Compound, etc.)
+struct PillBadge: View {
+    let text: String
+    var color: Color = .blue
+    var style: PillStyle = .filled
+
+    enum PillStyle {
+        case filled
+        case tinted
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, AppSpacing.xs)
+            .padding(.vertical, AppSpacing.xxs)
+            .foregroundColor(foregroundColor)
+            .background(backgroundColor)
+            .cornerRadius(AppCornerRadius.small)
+    }
+
+    private var foregroundColor: Color {
+        switch style {
+        case .filled:
+            return .white
+        case .tinted:
+            return color
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .filled:
+            return color
+        case .tinted:
+            return color.opacity(0.15)
+        }
+    }
+}
+
+// MARK: - Stat Card
+
+/// Metric display card with icon, value, label, and optional trend
+struct StatCard: View {
+    let icon: String
+    let value: String
+    let label: String
+    var trend: StatTrend?
+    var iconColor: Color = .blue
+
+    enum StatTrend {
+        case up(String)
+        case down(String)
+        case neutral(String)
+
+        var text: String {
+            switch self {
+            case .up(let val), .down(let val), .neutral(let val):
+                return val
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .up: return .green
+            case .down: return .red
+            case .neutral: return .secondary
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .up: return "arrow.up.right"
+            case .down: return "arrow.down.right"
+            case .neutral: return "minus"
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundColor(iconColor)
+
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            if let trend {
+                HStack(spacing: AppSpacing.xxs) {
+                    Image(systemName: trend.icon)
+                        .font(.caption2)
+                    Text(trend.text)
+                        .font(.caption2)
+                }
+                .foregroundColor(trend.color)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(AppSpacing.md)
+        .cardStyle()
+    }
+}
+
+// MARK: - Section Header
+
+/// Consistent section header with optional trailing action
+struct SectionHeader: View {
+    let title: String
+    var action: SectionAction?
+
+    struct SectionAction {
+        let label: String
+        let handler: () -> Void
+    }
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.headline)
+
+            Spacer()
+
+            if let action {
+                Button(action: action.handler) {
+                    Text(action.label)
+                        .font(.subheadline)
+                        .foregroundColor(.appTheme)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Icon Circle
+
+/// Colored circle with an SF Symbol icon inside
+struct IconCircle: View {
+    let icon: String
+    var color: Color = .blue
+    var size: CGFloat = 40
+
+    var body: some View {
+        Image(systemName: icon)
+            .font(.system(size: size * 0.4))
+            .foregroundColor(color)
+            .frame(width: size, height: size)
+            .background(color.opacity(0.15))
+            .clipShape(Circle())
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Pill Badges") {
+    HStack(spacing: AppSpacing.xs) {
+        PillBadge(text: "Active", color: .green)
+        PillBadge(text: "Compound", color: .blue, style: .tinted)
+        PillBadge(text: "Warmup", color: .orange, style: .tinted)
+        PillBadge(text: "8 Weeks", color: .purple, style: .tinted)
+    }
+    .padding()
+}
+
+#Preview("Stat Cards") {
+    HStack(spacing: AppSpacing.sm) {
+        StatCard(
+            icon: "flame.fill",
+            value: "4",
+            label: "This Week",
+            trend: .up("+1"),
+            iconColor: .orange
+        )
+        StatCard(
+            icon: "scalemass.fill",
+            value: "12.4K",
+            label: "Volume (lbs)",
+            trend: .up("+8%"),
+            iconColor: .blue
+        )
+    }
+    .padding()
+}
+
+#Preview("Section Header") {
+    VStack(spacing: AppSpacing.lg) {
+        SectionHeader(title: "Recent Workouts")
+        SectionHeader(
+            title: "My Programs",
+            action: .init(label: "See All", handler: {})
+        )
+    }
+    .padding()
+}
+
+#Preview("Icon Circles") {
+    HStack(spacing: AppSpacing.sm) {
+        IconCircle(icon: "dumbbell.fill", color: .blue)
+        IconCircle(icon: "figure.strengthtraining.traditional", color: .green)
+        IconCircle(icon: "heart.fill", color: .red, size: 32)
+    }
+    .padding()
+}

--- a/Nippardation/DesignSystem/TabBarConfiguration.swift
+++ b/Nippardation/DesignSystem/TabBarConfiguration.swift
@@ -1,0 +1,47 @@
+//
+//  TabBarConfiguration.swift
+//  Nippardation
+//
+//  Tab bar configuration for the bottom navigation
+//
+
+import SwiftUI
+
+/// Defines the 5 bottom tabs for the main navigation
+enum AppTab: String, CaseIterable, Hashable {
+    case home
+    case programs
+    case templates
+    case history
+    case profile
+
+    var label: String {
+        switch self {
+        case .home: return "Home"
+        case .programs: return "Programs"
+        case .templates: return "Templates"
+        case .history: return "History"
+        case .profile: return "Profile"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .home: return "house"
+        case .programs: return "list.bullet.clipboard"
+        case .templates: return "doc.text"
+        case .history: return "clock.arrow.circlepath"
+        case .profile: return "person"
+        }
+    }
+
+    var selectedIcon: String {
+        switch self {
+        case .home: return "house.fill"
+        case .programs: return "list.bullet.clipboard.fill"
+        case .templates: return "doc.text.fill"
+        case .history: return "clock.arrow.circlepath"
+        case .profile: return "person.fill"
+        }
+    }
+}

--- a/Nippardation/Home/HomeView.swift
+++ b/Nippardation/Home/HomeView.swift
@@ -10,212 +10,166 @@ import SwiftUI
 struct HomeView: View {
     @ObservedObject var viewModel = HomeViewModel()
     @ObservedObject private var workoutManager = WorkoutManager.shared
-    @EnvironmentObject private var authManager: AuthManager
-    
+
     @State private var startNewWorkout: Bool = false
     @State private var showActiveWorkout: Bool = false
-    @State private var error: Error? = nil
-    @State private var showErrorAlert: Bool = false
-    
+
     // Add state to track if we've done initial loading
     @State private var didCheckForActiveWorkout: Bool = false
-    
+
     var body: some View {
-        NavigationStack {
-            ZStack {
-                ScrollView {
-                    VStack(spacing: 16) {
-                        // Workout Stats Chart
-                        if !workoutManager.completedWorkouts.isEmpty {
-                            WorkoutStatsView()
-                                .padding(.top, 8)
-                        }
-                        
-                        // Workout Templates
-                        VStack(alignment: .leading) {
-                            Text("Workout Templates")
-                                .font(.headline)
-                                .padding(.horizontal)
-                            
-                            ForEach(viewModel.workouts, id: \.self) { workout in
-                                NavigationLink {
-                                    ExercisesListView(workout: workout)
-                                } label: {
-                                    HStack {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text(workout.name)
-                                                .font(.headline)
-                                                .foregroundColor(.primary)
-                                            
-                                            Text("\(workout.exercises.count) exercises")
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        
-                                        Spacer()
-                                        
-                                        Image(systemName: "chevron.right")
+        ZStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    // Workout Stats Chart
+                    if !workoutManager.completedWorkouts.isEmpty {
+                        WorkoutStatsView()
+                            .padding(.top, 8)
+                    }
+
+                    // Workout Templates
+                    VStack(alignment: .leading) {
+                        Text("Workout Templates")
+                            .font(.headline)
+                            .padding(.horizontal)
+
+                        ForEach(viewModel.workouts, id: \.self) { workout in
+                            NavigationLink {
+                                ExercisesListView(workout: workout)
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(workout.name)
+                                            .font(.headline)
+                                            .foregroundColor(.primary)
+
+                                        Text("\(workout.exercises.count) exercises")
+                                            .font(.subheadline)
                                             .foregroundColor(.secondary)
                                     }
-                                    .padding()
-                                    .background(Color(.secondarySystemBackground))
-                                    .cornerRadius(12)
+
+                                    Spacer()
+
+                                    Image(systemName: "chevron.right")
+                                        .foregroundColor(.secondary)
                                 }
+                                .padding()
+                                .background(Color(.secondarySystemBackground))
+                                .cornerRadius(12)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+
+                    // Recent Workouts Section
+                    if !workoutManager.completedWorkouts.isEmpty {
+                        VStack(alignment: .leading) {
+                            Text("Recent Workouts")
+                                .font(.headline)
+                                .padding(.horizontal)
+                                .padding(.top, 8)
+
+                            ForEach(workoutManager.completedWorkouts.prefix(3)) { workout in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(workout.workoutTemplate)
+                                            .font(.headline)
+
+                                        Text(workout.formattedDate)
+                                            .font(.subheadline)
+                                            .foregroundColor(.secondary)
+                                    }
+
+                                    Spacer()
+
+                                    if let duration = workout.formattedDuration {
+                                        Text(duration)
+                                            .font(.subheadline)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                                .padding()
+                                .background(Color(.secondarySystemBackground))
+                                .cornerRadius(12)
                             }
                             .padding(.horizontal)
                         }
-                        
-                        // Recent Workouts Section
-                        if !workoutManager.completedWorkouts.isEmpty {
-                            VStack(alignment: .leading) {
-                                Text("Recent Workouts")
-                                    .font(.headline)
-                                    .padding(.horizontal)
-                                    .padding(.top, 8)
-                                
-                                ForEach(workoutManager.completedWorkouts.prefix(3)) { workout in
-                                    HStack {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text(workout.workoutTemplate)
-                                                .font(.headline)
-                                            
-                                            Text(workout.formattedDate)
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        
-                                        Spacer()
-                                        
-                                        if let duration = workout.formattedDuration {
-                                            Text(duration)
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-                                    }
-                                    .padding()
-                                    .background(Color(.secondarySystemBackground))
-                                    .cornerRadius(12)
-                                }
-                                .padding(.horizontal)
-                            }
-                        }
-                        
-                        Spacer(minLength: 100)
                     }
+
+                    Spacer(minLength: 100)
                 }
-                
-                VStack {
+            }
+
+            VStack {
+                Spacer()
+
+                HStack {
                     Spacer()
-                    
-                    HStack {
-                        Spacer()
-                        
-                        // Conditionally show either Resume or Start New Workout button
-                        if workoutManager.isWorkoutInProgress {
-                            Button {
-                                showActiveWorkout = true
-                            } label: {
-                                HStack {
-                                    Image(systemName: "arrow.clockwise.circle")
-                                        .resizable()
-                                        .frame(width: 32, height: 32)
-                                        .aspectRatio(contentMode: .fit)
-                                    Text("Resume Workout")
-                                }
-                                .padding()
-                                .background(Color.green)
-                                .foregroundColor(.white)
-                                .cornerRadius(16)
-                                .shadow(radius: 2)
+
+                    // Conditionally show either Resume or Start New Workout button
+                    if workoutManager.isWorkoutInProgress {
+                        Button {
+                            showActiveWorkout = true
+                        } label: {
+                            HStack {
+                                Image(systemName: "arrow.clockwise.circle")
+                                    .resizable()
+                                    .frame(width: 32, height: 32)
+                                    .aspectRatio(contentMode: .fit)
+                                Text("Resume Workout")
                             }
-                        } else {
-                            Button {
-                                startNewWorkout = true
-                            } label: {
-                                HStack {
-                                    Image(systemName: "play.circle")
-                                        .resizable()
-                                        .frame(width: 32, height: 32)
-                                        .aspectRatio(contentMode: .fit)
-                                    Text("Start New Workout")
-                                }
-                                .padding()
-                                .background(Color.appTheme)
-                                .foregroundColor(.white)
-                                .cornerRadius(16)
-                                .shadow(radius: 2)
+                            .padding()
+                            .background(Color.green)
+                            .foregroundColor(.white)
+                            .cornerRadius(16)
+                            .shadow(radius: 2)
+                        }
+                    } else {
+                        Button {
+                            startNewWorkout = true
+                        } label: {
+                            HStack {
+                                Image(systemName: "play.circle")
+                                    .resizable()
+                                    .frame(width: 32, height: 32)
+                                    .aspectRatio(contentMode: .fit)
+                                Text("Start New Workout")
                             }
+                            .padding()
+                            .background(Color.appTheme)
+                            .foregroundColor(.white)
+                            .cornerRadius(16)
+                            .shadow(radius: 2)
                         }
-                    }
-                }
-                .padding()
-                .sheet(isPresented: $startNewWorkout) {
-                    WorkoutSelectionView { workout in
-                        self.showActiveWorkout = true
-                    }
-                }
-                .fullScreenCover(isPresented: $showActiveWorkout) {
-                    if let activeWorkout = workoutManager.activeWorkout {
-                        NavigationStack {
-                            ActiveWorkoutView(workout: activeWorkout)
-                        }
-                    }
-                }
-
-            }
-            .navigationTitle("Home")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    HStack(spacing: 16) {
-                        NavigationLink(destination: TemplateListView()) {
-                            Image(systemName: "doc.text")
-                        }
-                        NavigationLink(destination: ProgramListView()) {
-                            Image(systemName: "list.bullet.clipboard")
-                        }
-                    }
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Menu {
-                        if let user = authManager.user {
-                            Label(user.email ?? "User", systemImage: "person.circle")
-                        }
-
-                        Divider()
-
-                        Button(action: {
-                            signOut()
-                        }) {
-                            Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
-                        }
-                    } label: {
-                        Image(systemName: "person.circle")
-                            .foregroundColor(.appTheme)
                     }
                 }
             }
-            .onAppear {
-                // Refresh workout data when the view appears
-                workoutManager.loadCompletedWorkouts()
-                
-                // Check for active workout on first appear only
-                if !didCheckForActiveWorkout {
-                    // Explicitly force the WorkoutManager to check for cached workout
-                    workoutManager.checkForActiveWorkout()
-                    didCheckForActiveWorkout = true
+            .padding()
+            .sheet(isPresented: $startNewWorkout) {
+                WorkoutSelectionView { workout in
+                    self.showActiveWorkout = true
                 }
             }
+            .fullScreenCover(isPresented: $showActiveWorkout) {
+                if let activeWorkout = workoutManager.activeWorkout {
+                    NavigationStack {
+                        ActiveWorkoutView(workout: activeWorkout)
+                    }
+                }
+            }
+
         }
-        
-        .tint(Color.appTheme)
-    }
-    
-    func signOut() {
-        do {
-            try authManager.signOut()
-        } catch let authError {
-            error = authError
-            showErrorAlert = true
+        .navigationTitle("Home")
+        .onAppear {
+            // Refresh workout data when the view appears
+            workoutManager.loadCompletedWorkouts()
+
+            // Check for active workout on first appear only
+            if !didCheckForActiveWorkout {
+                // Explicitly force the WorkoutManager to check for cached workout
+                workoutManager.checkForActiveWorkout()
+                didCheckForActiveWorkout = true
+            }
         }
     }
 }

--- a/Nippardation/NippardationApp.swift
+++ b/Nippardation/NippardationApp.swift
@@ -38,7 +38,7 @@ struct NippardationApp: App {
     var body: some Scene {
         WindowGroup {
             if authManager.isAuthenticated {
-                HomeView()
+                MainTabView()
                     .environmentObject(authManager)
                     .onChange(of: UIApplication.shared.applicationState) { oldState, newState in
                         if newState == .background {

--- a/Nippardation/Views/Dashboard/DashboardView.swift
+++ b/Nippardation/Views/Dashboard/DashboardView.swift
@@ -12,38 +12,24 @@ struct DashboardView: View {
     @StateObject private var viewModel = DashboardViewModel()
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 24) {
-                    if viewModel.isLoading && viewModel.activeProgram == nil {
-                        ProgressView()
-                            .padding(.top, 50)
-                    } else if let program = viewModel.activeProgram {
-                        // Active program content
-                        activeProgramContent(program)
-                    } else {
-                        // No active program
-                        noProgramContent
-                    }
-                }
-                .padding()
-            }
-            .navigationTitle("Dashboard")
-            .refreshable {
-                await viewModel.refreshAsync()
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 16) {
-                        NavigationLink(destination: TemplateListView()) {
-                            Image(systemName: "doc.text")
-                        }
-                        NavigationLink(destination: ProgramListView()) {
-                            Image(systemName: "list.bullet.clipboard")
-                        }
-                    }
+        ScrollView {
+            VStack(spacing: 24) {
+                if viewModel.isLoading && viewModel.activeProgram == nil {
+                    ProgressView()
+                        .padding(.top, 50)
+                } else if let program = viewModel.activeProgram {
+                    // Active program content
+                    activeProgramContent(program)
+                } else {
+                    // No active program
+                    noProgramContent
                 }
             }
+            .padding()
+        }
+        .navigationTitle("Dashboard")
+        .refreshable {
+            await viewModel.refreshAsync()
         }
         .onAppear {
             viewModel.loadDashboard()

--- a/Nippardation/Views/Root/HistoryPlaceholderView.swift
+++ b/Nippardation/Views/Root/HistoryPlaceholderView.swift
@@ -1,0 +1,25 @@
+//
+//  HistoryPlaceholderView.swift
+//  Nippardation
+//
+//  Placeholder for the History tab (coming soon)
+//
+
+import SwiftUI
+
+struct HistoryPlaceholderView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "Coming Soon",
+            systemImage: "clock.arrow.circlepath",
+            description: Text("Your full workout history will appear here in a future update.")
+        )
+        .navigationTitle("History")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HistoryPlaceholderView()
+    }
+}

--- a/Nippardation/Views/Root/MainTabView.swift
+++ b/Nippardation/Views/Root/MainTabView.swift
@@ -1,0 +1,63 @@
+//
+//  MainTabView.swift
+//  Nippardation
+//
+//  Root view wrapping the authenticated experience in a 5-tab TabView
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    @EnvironmentObject private var authManager: AuthManager
+    @State private var selectedTab: AppTab = .home
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            NavigationStack {
+                HomeView()
+            }
+            .tag(AppTab.home)
+            .tabItem {
+                Label(AppTab.home.label, systemImage: AppTab.home.icon)
+            }
+
+            NavigationStack {
+                ProgramListView()
+            }
+            .tag(AppTab.programs)
+            .tabItem {
+                Label(AppTab.programs.label, systemImage: AppTab.programs.icon)
+            }
+
+            NavigationStack {
+                TemplateListView()
+            }
+            .tag(AppTab.templates)
+            .tabItem {
+                Label(AppTab.templates.label, systemImage: AppTab.templates.icon)
+            }
+
+            NavigationStack {
+                HistoryPlaceholderView()
+            }
+            .tag(AppTab.history)
+            .tabItem {
+                Label(AppTab.history.label, systemImage: AppTab.history.icon)
+            }
+
+            NavigationStack {
+                ProfilePlaceholderView()
+            }
+            .tag(AppTab.profile)
+            .tabItem {
+                Label(AppTab.profile.label, systemImage: AppTab.profile.icon)
+            }
+        }
+        .tint(Color.appTheme)
+    }
+}
+
+#Preview {
+    MainTabView()
+        .environmentObject(AuthManager.shared)
+}

--- a/Nippardation/Views/Root/ProfilePlaceholderView.swift
+++ b/Nippardation/Views/Root/ProfilePlaceholderView.swift
@@ -1,0 +1,68 @@
+//
+//  ProfilePlaceholderView.swift
+//  Nippardation
+//
+//  Profile tab with user info and sign out (relocated from HomeView toolbar)
+//
+
+import SwiftUI
+
+struct ProfilePlaceholderView: View {
+    @EnvironmentObject private var authManager: AuthManager
+    @State private var error: Error?
+    @State private var showErrorAlert = false
+
+    var body: some View {
+        List {
+            Section {
+                HStack(spacing: AppSpacing.md) {
+                    Image(systemName: "person.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(.appTheme)
+
+                    VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                        Text(authManager.backendUser?.displayName ?? "User")
+                            .font(.headline)
+
+                        if let email = authManager.user?.email {
+                            Text(email)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .padding(.vertical, AppSpacing.xs)
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    signOut()
+                } label: {
+                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
+        }
+        .navigationTitle("Profile")
+        .alert("Sign Out Error", isPresented: $showErrorAlert) {
+            Button("OK") {}
+        } message: {
+            Text(error?.localizedDescription ?? "An unknown error occurred")
+        }
+    }
+
+    private func signOut() {
+        do {
+            try authManager.signOut()
+        } catch {
+            self.error = error
+            showErrorAlert = true
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfilePlaceholderView()
+            .environmentObject(AuthManager.shared)
+    }
+}


### PR DESCRIPTION
## Summary

- **MainTabView**: New root view wrapping the app in a 5-tab `TabView` (Home, Programs, Templates, History, Profile), each tab with its own `NavigationStack`
- **HistoryPlaceholderView**: "Coming Soon" placeholder for the History tab
- **ProfilePlaceholderView**: User info display + sign out button (relocated from HomeView toolbar menu)
- **HomeView**: Removed `NavigationStack` wrapper, toolbar nav links to templates/programs, and sign-out menu — all now handled by tabs
- **DashboardView**: Removed `NavigationStack` wrapper and toolbar nav links
- **NippardationApp**: Entry point now renders `MainTabView` instead of `HomeView`

## Context

PR2 of 10 in the UI revamp. Depends on PR1 (#17) for `AppTab` enum. This restructures the app's navigation from toolbar-based to bottom tab bar, which is the foundation for all subsequent view PRs.

## Test plan

- [x] `xcodebuild build` passes
- [x] All existing tests pass (flaky `UserAPIServiceTests/handlesUnauthorized` passes in isolation — pre-existing)
- [x] 5 tabs visible and navigable
- [x] Workout tracking flow (Start → Track → End) preserved via `fullScreenCover`
- [x] Sign out relocated to Profile tab and functional
- [x] Templates and Programs accessible via their own tabs
- [x] ~310 net line additions (well within 1000-line limit)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the authenticated root view and navigation structure (TabView + per-tab NavigationStack), which can impact routing/state restoration and sign-out behavior, but does not touch backend/data logic.
> 
> **Overview**
> Introduces a new authenticated root navigation based on a 5-tab `TabView` via `MainTabView` (Home, Programs, Templates, History, Profile) driven by the new `AppTab` configuration.
> 
> Moves user account/sign-out UI out of `HomeView` into a new `ProfilePlaceholderView`, and adds a `HistoryPlaceholderView` for the new History tab. `HomeView` and `DashboardView` are simplified by removing their internal `NavigationStack`/toolbar navigation in favor of tab-based navigation, and `NippardationApp` now launches `MainTabView` when authenticated.
> 
> Adds a small design system layer (`AppSpacing`, `AppCornerRadius`, card-style modifiers) plus a few reusable components (`PillBadge`, `StatCard`, `SectionHeader`, `IconCircle`) to standardize upcoming UI work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c480796ad378da25390c9852136224bfb42180a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->