### PR TITLE
Revamp home dashboard with hero card, stats, and plan details

### DIFF
--- a/Nippardation/Home/HomeView.swift
+++ b/Nippardation/Home/HomeView.swift
@@ -10,212 +10,166 @@ import SwiftUI
 struct HomeView: View {
     @ObservedObject var viewModel = HomeViewModel()
     @ObservedObject private var workoutManager = WorkoutManager.shared
-    @EnvironmentObject private var authManager: AuthManager
-    
+
     @State private var startNewWorkout: Bool = false
     @State private var showActiveWorkout: Bool = false
-    @State private var error: Error? = nil
-    @State private var showErrorAlert: Bool = false
-    
+
     // Add state to track if we've done initial loading
     @State private var didCheckForActiveWorkout: Bool = false
-    
+
     var body: some View {
-        NavigationStack {
-            ZStack {
-                ScrollView {
-                    VStack(spacing: 16) {
-                        // Workout Stats Chart
-                        if !workoutManager.completedWorkouts.isEmpty {
-                            WorkoutStatsView()
-                                .padding(.top, 8)
-                        }
-                        
-                        // Workout Templates
-                        VStack(alignment: .leading) {
-                            Text("Workout Templates")
-                                .font(.headline)
-                                .padding(.horizontal)
-                            
-                            ForEach(viewModel.workouts, id: \.self) { workout in
-                                NavigationLink {
-                                    ExercisesListView(workout: workout)
-                                } label: {
-                                    HStack {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text(workout.name)
-                                                .font(.headline)
-                                                .foregroundColor(.primary)
-                                            
-                                            Text("\(workout.exercises.count) exercises")
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        
-                                        Spacer()
-                                        
-                                        Image(systemName: "chevron.right")
+        ZStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    // Workout Stats Chart
+                    if !workoutManager.completedWorkouts.isEmpty {
+                        WorkoutStatsView()
+                            .padding(.top, 8)
+                    }
+
+                    // Workout Templates
+                    VStack(alignment: .leading) {
+                        Text("Workout Templates")
+                            .font(.headline)
+                            .padding(.horizontal)
+
+                        ForEach(viewModel.workouts, id: \.self) { workout in
+                            NavigationLink {
+                                ExercisesListView(workout: workout)
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(workout.name)
+                                            .font(.headline)
+                                            .foregroundColor(.primary)
+
+                                        Text("\(workout.exercises.count) exercises")
+                                            .font(.subheadline)
                                             .foregroundColor(.secondary)
                                     }
-                                    .padding()
-                                    .background(Color(.secondarySystemBackground))
-                                    .cornerRadius(12)
+
+                                    Spacer()
+
+                                    Image(systemName: "chevron.right")
+                                        .foregroundColor(.secondary)
                                 }
+                                .padding()
+                                .background(Color(.secondarySystemBackground))
+                                .cornerRadius(12)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+
+                    // Recent Workouts Section
+                    if !workoutManager.completedWorkouts.isEmpty {
+                        VStack(alignment: .leading) {
+                            Text("Recent Workouts")
+                                .font(.headline)
+                                .padding(.horizontal)
+                                .padding(.top, 8)
+
+                            ForEach(workoutManager.completedWorkouts.prefix(3)) { workout in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(workout.workoutTemplate)
+                                            .font(.headline)
+
+                                        Text(workout.formattedDate)
+                                            .font(.subheadline)
+                                            .foregroundColor(.secondary)
+                                    }
+
+                                    Spacer()
+
+                                    if let duration = workout.formattedDuration {
+                                        Text(duration)
+                                            .font(.subheadline)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                                .padding()
+                                .background(Color(.secondarySystemBackground))
+                                .cornerRadius(12)
                             }
                             .padding(.horizontal)
                         }
-                        
-                        // Recent Workouts Section
-                        if !workoutManager.completedWorkouts.isEmpty {
-                            VStack(alignment: .leading) {
-                                Text("Recent Workouts")
-                                    .font(.headline)
-                                    .padding(.horizontal)
-                                    .padding(.top, 8)
-                                
-                                ForEach(workoutManager.completedWorkouts.prefix(3)) { workout in
-                                    HStack {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text(workout.workoutTemplate)
-                                                .font(.headline)
-                                            
-                                            Text(workout.formattedDate)
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        
-                                        Spacer()
-                                        
-                                        if let duration = workout.formattedDuration {
-                                            Text(duration)
-                                                .font(.subheadline)
-                                                .foregroundColor(.secondary)
-                                        }
-                                    }
-                                    .padding()
-                                    .background(Color(.secondarySystemBackground))
-                                    .cornerRadius(12)
-                                }
-                                .padding(.horizontal)
-                            }
-                        }
-                        
-                        Spacer(minLength: 100)
                     }
+
+                    Spacer(minLength: 100)
                 }
-                
-                VStack {
+            }
+
+            VStack {
+                Spacer()
+
+                HStack {
                     Spacer()
-                    
-                    HStack {
-                        Spacer()
-                        
-                        // Conditionally show either Resume or Start New Workout button
-                        if workoutManager.isWorkoutInProgress {
-                            Button {
-                                showActiveWorkout = true
-                            } label: {
-                                HStack {
-                                    Image(systemName: "arrow.clockwise.circle")
-                                        .resizable()
-                                        .frame(width: 32, height: 32)
-                                        .aspectRatio(contentMode: .fit)
-                                    Text("Resume Workout")
-                                }
-                                .padding()
-                                .background(Color.green)
-                                .foregroundColor(.white)
-                                .cornerRadius(16)
-                                .shadow(radius: 2)
+
+                    // Conditionally show either Resume or Start New Workout button
+                    if workoutManager.isWorkoutInProgress {
+                        Button {
+                            showActiveWorkout = true
+                        } label: {
+                            HStack {
+                                Image(systemName: "arrow.clockwise.circle")
+                                    .resizable()
+                                    .frame(width: 32, height: 32)
+                                    .aspectRatio(contentMode: .fit)
+                                Text("Resume Workout")
                             }
-                        } else {
-                            Button {
-                                startNewWorkout = true
-                            } label: {
-                                HStack {
-                                    Image(systemName: "play.circle")
-                                        .resizable()
-                                        .frame(width: 32, height: 32)
-                                        .aspectRatio(contentMode: .fit)
-                                    Text("Start New Workout")
-                                }
-                                .padding()
-                                .background(Color.appTheme)
-                                .foregroundColor(.white)
-                                .cornerRadius(16)
-                                .shadow(radius: 2)
+                            .padding()
+                            .background(Color.green)
+                            .foregroundColor(.white)
+                            .cornerRadius(16)
+                            .shadow(radius: 2)
+                        }
+                    } else {
+                        Button {
+                            startNewWorkout = true
+                        } label: {
+                            HStack {
+                                Image(systemName: "play.circle")
+                                    .resizable()
+                                    .frame(width: 32, height: 32)
+                                    .aspectRatio(contentMode: .fit)
+                                Text("Start New Workout")
                             }
+                            .padding()
+                            .background(Color.appTheme)
+                            .foregroundColor(.white)
+                            .cornerRadius(16)
+                            .shadow(radius: 2)
                         }
-                    }
-                }
-                .padding()
-                .sheet(isPresented: $startNewWorkout) {
-                    WorkoutSelectionView { workout in
-                        self.showActiveWorkout = true
-                    }
-                }
-                .fullScreenCover(isPresented: $showActiveWorkout) {
-                    if let activeWorkout = workoutManager.activeWorkout {
-                        NavigationStack {
-                            ActiveWorkoutView(workout: activeWorkout)
-                        }
-                    }
-                }
-
-            }
-            .navigationTitle("Home")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    HStack(spacing: 16) {
-                        NavigationLink(destination: TemplateListView()) {
-                            Image(systemName: "doc.text")
-                        }
-                        NavigationLink(destination: ProgramListView()) {
-                            Image(systemName: "list.bullet.clipboard")
-                        }
-                    }
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Menu {
-                        if let user = authManager.user {
-                            Label(user.email ?? "User", systemImage: "person.circle")
-                        }
-
-                        Divider()
-
-                        Button(action: {
-                            signOut()
-                        }) {
-                            Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
-                        }
-                    } label: {
-                        Image(systemName: "person.circle")
-                            .foregroundColor(.appTheme)
                     }
                 }
             }
-            .onAppear {
-                // Refresh workout data when the view appears
-                workoutManager.loadCompletedWorkouts()
-                
-                // Check for active workout on first appear only
-                if !didCheckForActiveWorkout {
-                    // Explicitly force the WorkoutManager to check for cached workout
-                    workoutManager.checkForActiveWorkout()
-                    didCheckForActiveWorkout = true
+            .padding()
+            .sheet(isPresented: $startNewWorkout) {
+                WorkoutSelectionView { workout in
+                    self.showActiveWorkout = true
                 }
             }
+            .fullScreenCover(isPresented: $showActiveWorkout) {
+                if let activeWorkout = workoutManager.activeWorkout {
+                    NavigationStack {
+                        ActiveWorkoutView(workout: activeWorkout)
+                    }
+                }
+            }
+
         }
-        
-        .tint(Color.appTheme)
-    }
-    
-    func signOut() {
-        do {
-            try authManager.signOut()
-        } catch let authError {
-            error = authError
-            showErrorAlert = true
+        .navigationTitle("Home")
+        .onAppear {
+            // Refresh workout data when the view appears
+            workoutManager.loadCompletedWorkouts()
+
+            // Check for active workout on first appear only
+            if !didCheckForActiveWorkout {
+                // Explicitly force the WorkoutManager to check for cached workout
+                workoutManager.checkForActiveWorkout()
+                didCheckForActiveWorkout = true
+            }
         }
     }
 }

--- a/Nippardation/Home/HomeView.swift
+++ b/Nippardation/Home/HomeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HomeView: View {
-    @ObservedObject var viewModel = HomeViewModel()
+    @StateObject private var viewModel = HomeViewModel()
     @ObservedObject private var workoutManager = WorkoutManager.shared
 
     @State private var startNewWorkout: Bool = false
@@ -20,93 +20,56 @@ struct HomeView: View {
     var body: some View {
         ZStack {
             ScrollView {
-                VStack(spacing: 16) {
-                    // Workout Stats Chart
+                VStack(spacing: AppSpacing.lg) {
+                    // Hero workout card
+                    heroSection
+                        .padding(.horizontal, AppSpacing.md)
+                        .padding(.top, AppSpacing.xs)
+
+                    // Activity stats
+                    if !workoutManager.completedWorkouts.isEmpty {
+                        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                            SectionHeader(title: "This Week")
+                                .padding(.horizontal, AppSpacing.md)
+
+                            ActivityStatCards(
+                                workoutsThisWeek: viewModel.workoutsThisWeek,
+                                totalVolume: viewModel.totalVolumeFormatted,
+                                weeklyConsistency: viewModel.weeklyConsistency
+                            )
+                        }
+                    }
+
+                    // Volume chart
                     if !workoutManager.completedWorkouts.isEmpty {
                         WorkoutStatsView()
-                            .padding(.top, 8)
+                            .padding(.horizontal, AppSpacing.md)
                     }
 
-                    // Workout Templates
-                    VStack(alignment: .leading) {
-                        Text("Workout Templates")
-                            .font(.headline)
-                            .padding(.horizontal)
-
-                        ForEach(viewModel.workouts, id: \.self) { workout in
-                            NavigationLink {
-                                ExercisesListView(workout: workout)
-                            } label: {
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(workout.name)
-                                            .font(.headline)
-                                            .foregroundColor(.primary)
-
-                                        Text("\(workout.exercises.count) exercises")
-                                            .font(.subheadline)
-                                            .foregroundColor(.secondary)
-                                    }
-
-                                    Spacer()
-
-                                    Image(systemName: "chevron.right")
-                                        .foregroundColor(.secondary)
-                                }
-                                .padding()
-                                .background(Color(.secondarySystemBackground))
-                                .cornerRadius(12)
-                            }
-                        }
-                        .padding(.horizontal)
-                    }
+                    // Active plan details
+                    PlanDetailsSection(
+                        program: viewModel.activeProgram,
+                        nextWorkout: viewModel.nextWorkout
+                    )
+                    .padding(.horizontal, AppSpacing.md)
 
                     // Recent Workouts Section
                     if !workoutManager.completedWorkouts.isEmpty {
-                        VStack(alignment: .leading) {
-                            Text("Recent Workouts")
-                                .font(.headline)
-                                .padding(.horizontal)
-                                .padding(.top, 8)
-
-                            ForEach(workoutManager.completedWorkouts.prefix(3)) { workout in
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(workout.workoutTemplate)
-                                            .font(.headline)
-
-                                        Text(workout.formattedDate)
-                                            .font(.subheadline)
-                                            .foregroundColor(.secondary)
-                                    }
-
-                                    Spacer()
-
-                                    if let duration = workout.formattedDuration {
-                                        Text(duration)
-                                            .font(.subheadline)
-                                            .foregroundColor(.secondary)
-                                    }
-                                }
-                                .padding()
-                                .background(Color(.secondarySystemBackground))
-                                .cornerRadius(12)
-                            }
-                            .padding(.horizontal)
-                        }
+                        recentWorkoutsSection
+                            .padding(.horizontal, AppSpacing.md)
                     }
 
                     Spacer(minLength: 100)
                 }
             }
 
+            // FAB overlay
             VStack {
                 Spacer()
 
                 HStack {
                     Spacer()
 
-                    // Conditionally show either Resume or Start New Workout button
                     if workoutManager.isWorkoutInProgress {
                         Button {
                             showActiveWorkout = true
@@ -121,7 +84,7 @@ struct HomeView: View {
                             .padding()
                             .background(Color.green)
                             .foregroundColor(.white)
-                            .cornerRadius(16)
+                            .cornerRadius(AppCornerRadius.large)
                             .shadow(radius: 2)
                         }
                     } else {
@@ -138,7 +101,7 @@ struct HomeView: View {
                             .padding()
                             .background(Color.appTheme)
                             .foregroundColor(.white)
-                            .cornerRadius(16)
+                            .cornerRadius(AppCornerRadius.large)
                             .shadow(radius: 2)
                         }
                     }
@@ -157,23 +120,82 @@ struct HomeView: View {
                     }
                 }
             }
-
         }
         .navigationTitle("Home")
         .onAppear {
-            // Refresh workout data when the view appears
             workoutManager.loadCompletedWorkouts()
+            viewModel.loadDashboard()
+            viewModel.computeWeeklyStats(from: workoutManager.completedWorkouts)
 
-            // Check for active workout on first appear only
             if !didCheckForActiveWorkout {
-                // Explicitly force the WorkoutManager to check for cached workout
                 workoutManager.checkForActiveWorkout()
                 didCheckForActiveWorkout = true
+            }
+        }
+        .onChange(of: workoutManager.completedWorkouts.count) {
+            viewModel.computeWeeklyStats(from: workoutManager.completedWorkouts)
+        }
+    }
+
+    // MARK: - Hero Section
+
+    @ViewBuilder
+    private var heroSection: some View {
+        if let program = viewModel.activeProgram {
+            HeroWorkoutCard(
+                workout: viewModel.nextWorkout,
+                template: viewModel.nextTemplate,
+                programProgress: program.progress,
+                onStart: {
+                    if workoutManager.isWorkoutInProgress {
+                        showActiveWorkout = true
+                    } else {
+                        startNewWorkout = true
+                    }
+                }
+            )
+        } else {
+            HeroWorkoutFallbackCard(onChooseProgram: {
+                startNewWorkout = true
+            })
+        }
+    }
+
+    // MARK: - Recent Workouts
+
+    private var recentWorkoutsSection: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            SectionHeader(title: "Recent Workouts")
+
+            ForEach(workoutManager.completedWorkouts.prefix(3)) { workout in
+                HStack {
+                    VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                        Text(workout.workoutTemplate)
+                            .font(.headline)
+
+                        Text(workout.formattedDate)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer()
+
+                    if let duration = workout.formattedDuration {
+                        Text(duration)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding(AppSpacing.md)
+                .cardStyle()
             }
         }
     }
 }
 
 #Preview {
-    HomeView()
+    NavigationStack {
+        HomeView()
+    }
+    .withDependencies(.preview)
 }

--- a/Nippardation/Home/HomeViewModel.swift
+++ b/Nippardation/Home/HomeViewModel.swift
@@ -8,12 +8,120 @@
 import SwiftUI
 import Combine
 
+@MainActor
 class HomeViewModel: ObservableObject {
-    @State var workouts: [Workout] = [
+    // Legacy workout templates (kept for backward compatibility)
+    @Published var workouts: [Workout] = [
         upperStrength,
         lowerStrength,
         pullDay,
         pushDay,
         legDay
     ]
+
+    // Active program data
+    @Published var activeProgram: Program?
+    @Published var nextWorkout: ProgramWorkout?
+    @Published var nextTemplate: Template?
+
+    // Stats
+    @Published var workoutsThisWeek: Int = 0
+    @Published var totalVolumeFormatted: String = "0"
+    @Published var weeklyConsistency: Int = 0
+
+    @Published var isLoading = false
+    @Published var error: String?
+
+    private let programRepository: any ProgramRepositoryProtocol
+    private let templateRepository: any TemplateRepositoryProtocol
+    private let taskManager = TaskManager()
+
+    init(
+        programRepository: (any ProgramRepositoryProtocol)? = nil,
+        templateRepository: (any TemplateRepositoryProtocol)? = nil
+    ) {
+        self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+        self.templateRepository = templateRepository ?? DependencyContainer.shared.templateRepository
+    }
+
+    // MARK: - Loading
+
+    func loadDashboard() {
+        Task { @MainActor in
+            await taskManager.run(id: "loadDashboard") { [weak self] in
+                guard let self else { return }
+                await MainActor.run { self.isLoading = true }
+
+                do {
+                    let program = try await self.programRepository.getActiveProgram()
+                    await MainActor.run {
+                        self.activeProgram = program
+                        self.nextWorkout = program?.currentWorkout
+
+                        if let workout = program?.currentWorkout {
+                            self.nextTemplate = workout.template
+                        }
+                    }
+
+                    // Load template if not attached to workout
+                    if let workout = program?.currentWorkout,
+                       workout.template == nil {
+                        let templates = try await self.templateRepository.fetchTemplates()
+                        await MainActor.run {
+                            self.nextTemplate = templates.first { $0.serverId == workout.templateServerId }
+                        }
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.error = error.localizedDescription
+                    }
+                }
+
+                await MainActor.run { self.isLoading = false }
+            }
+        }
+    }
+
+    func computeWeeklyStats(from completedWorkouts: [TrackedWorkout]) {
+        let calendar = Calendar.current
+        let now = Date()
+        let startOfWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: now)) ?? now
+
+        // Workouts this week
+        workoutsThisWeek = completedWorkouts.filter { $0.date >= startOfWeek }.count
+
+        // Total volume (last 30 days)
+        let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: now) ?? now
+        let recentWorkouts = completedWorkouts.filter { $0.date >= thirtyDaysAgo }
+        var totalVolume: Double = 0
+        for workout in recentWorkouts {
+            for exercise in workout.trackedExercises {
+                for set in exercise.trackedSets {
+                    totalVolume += set.weight * Double(set.reps)
+                }
+            }
+        }
+        if totalVolume >= 1000 {
+            totalVolumeFormatted = String(format: "%.1fK lbs", totalVolume / 1000)
+        } else {
+            totalVolumeFormatted = String(format: "%.0f lbs", totalVolume)
+        }
+
+        // Weekly consistency (last 4 weeks)
+        let fourWeeksAgo = calendar.date(byAdding: .weekOfYear, value: -4, to: now) ?? now
+        let lastFourWeeksWorkouts = completedWorkouts.filter { $0.date >= fourWeeksAgo }
+        var weeksWithWorkouts = 0
+        for weekOffset in 0..<4 {
+            let weekStart = calendar.date(byAdding: .weekOfYear, value: -weekOffset, to: startOfWeek) ?? now
+            let weekEnd = calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart) ?? now
+            if lastFourWeeksWorkouts.contains(where: { $0.date >= weekStart && $0.date < weekEnd }) {
+                weeksWithWorkouts += 1
+            }
+        }
+        weeklyConsistency = weeksWithWorkouts * 25 // out of 100%
+    }
+
+    func clearError() {
+        error = nil
+    }
 }

--- a/Nippardation/NippardationApp.swift
+++ b/Nippardation/NippardationApp.swift
@@ -38,7 +38,7 @@ struct NippardationApp: App {
     var body: some Scene {
         WindowGroup {
             if authManager.isAuthenticated {
-                HomeView()
+                MainTabView()
                     .environmentObject(authManager)
                     .onChange(of: UIApplication.shared.applicationState) { oldState, newState in
                         if newState == .background {

--- a/Nippardation/Views/Dashboard/DashboardView.swift
+++ b/Nippardation/Views/Dashboard/DashboardView.swift
@@ -12,38 +12,24 @@ struct DashboardView: View {
     @StateObject private var viewModel = DashboardViewModel()
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 24) {
-                    if viewModel.isLoading && viewModel.activeProgram == nil {
-                        ProgressView()
-                            .padding(.top, 50)
-                    } else if let program = viewModel.activeProgram {
-                        // Active program content
-                        activeProgramContent(program)
-                    } else {
-                        // No active program
-                        noProgramContent
-                    }
-                }
-                .padding()
-            }
-            .navigationTitle("Dashboard")
-            .refreshable {
-                await viewModel.refreshAsync()
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 16) {
-                        NavigationLink(destination: TemplateListView()) {
-                            Image(systemName: "doc.text")
-                        }
-                        NavigationLink(destination: ProgramListView()) {
-                            Image(systemName: "list.bullet.clipboard")
-                        }
-                    }
+        ScrollView {
+            VStack(spacing: 24) {
+                if viewModel.isLoading && viewModel.activeProgram == nil {
+                    ProgressView()
+                        .padding(.top, 50)
+                } else if let program = viewModel.activeProgram {
+                    // Active program content
+                    activeProgramContent(program)
+                } else {
+                    // No active program
+                    noProgramContent
                 }
             }
+            .padding()
+        }
+        .navigationTitle("Dashboard")
+        .refreshable {
+            await viewModel.refreshAsync()
         }
         .onAppear {
             viewModel.loadDashboard()

--- a/Nippardation/Views/Home/ActivityStatCards.swift
+++ b/Nippardation/Views/Home/ActivityStatCards.swift
@@ -1,0 +1,53 @@
+//
+//  ActivityStatCards.swift
+//  Nippardation
+//
+//  Horizontal ScrollView of stat cards for the home dashboard
+//
+
+import SwiftUI
+
+struct ActivityStatCards: View {
+    let workoutsThisWeek: Int
+    let totalVolume: String
+    let weeklyConsistency: Int
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: AppSpacing.sm) {
+                StatCard(
+                    icon: "flame.fill",
+                    value: "\(workoutsThisWeek)",
+                    label: "This Week",
+                    iconColor: .orange
+                )
+                .frame(width: 140)
+
+                StatCard(
+                    icon: "scalemass.fill",
+                    value: totalVolume,
+                    label: "Total Volume",
+                    iconColor: .blue
+                )
+                .frame(width: 140)
+
+                StatCard(
+                    icon: "chart.bar.fill",
+                    value: "\(weeklyConsistency)%",
+                    label: "Consistency",
+                    iconColor: .green
+                )
+                .frame(width: 140)
+            }
+            .padding(.horizontal, AppSpacing.md)
+        }
+    }
+}
+
+#Preview {
+    ActivityStatCards(
+        workoutsThisWeek: 4,
+        totalVolume: "12.4K lbs",
+        weeklyConsistency: 85
+    )
+}

--- a/Nippardation/Views/Home/CircularProgressView.swift
+++ b/Nippardation/Views/Home/CircularProgressView.swift
@@ -1,0 +1,46 @@
+//
+//  CircularProgressView.swift
+//  Nippardation
+//
+//  Reusable ring progress indicator
+//
+
+import SwiftUI
+
+struct CircularProgressView: View {
+    let progress: Double
+    var lineWidth: CGFloat = 8
+    var trackColor: Color = Color.secondary.opacity(0.2)
+    var progressColor: Color = .appTheme
+    var size: CGFloat = 60
+
+    var body: some View {
+        ZStack {
+            // Background track
+            Circle()
+                .stroke(trackColor, lineWidth: lineWidth)
+
+            // Progress arc
+            Circle()
+                .trim(from: 0, to: min(progress, 1.0))
+                .stroke(progressColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+
+            // Center percentage text
+            Text("\(Int(min(progress, 1.0) * 100))%")
+                .font(.system(size: size * 0.22, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+#Preview("Progress States") {
+    HStack(spacing: AppSpacing.lg) {
+        CircularProgressView(progress: 0.0)
+        CircularProgressView(progress: 0.35, progressColor: .orange)
+        CircularProgressView(progress: 0.75, progressColor: .green)
+        CircularProgressView(progress: 1.0, progressColor: .blue, size: 80)
+    }
+    .padding()
+}

--- a/Nippardation/Views/Home/HeroWorkoutCard.swift
+++ b/Nippardation/Views/Home/HeroWorkoutCard.swift
@@ -1,0 +1,127 @@
+//
+//  HeroWorkoutCard.swift
+//  Nippardation
+//
+//  Hero card showing the current/next workout from the active program
+//
+
+import SwiftUI
+
+struct HeroWorkoutCard: View {
+    let workout: ProgramWorkout?
+    let template: Template?
+    let programProgress: Double
+    let onStart: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.md) {
+            // Top row: badge + progress ring
+            HStack {
+                VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                    PillBadge(text: "Today's Focus", color: .appTheme, style: .tinted)
+
+                    Text(workout?.displayName ?? "Ready to Train")
+                        .font(.title2)
+                        .fontWeight(.bold)
+
+                    if let template {
+                        Text(muscleGroupSummary(for: template))
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                CircularProgressView(
+                    progress: programProgress,
+                    progressColor: .appTheme,
+                    size: 56
+                )
+            }
+
+            // Info pills
+            if let template {
+                HStack(spacing: AppSpacing.sm) {
+                    Label("\(template.exerciseCount) exercises", systemImage: "figure.strengthtraining.traditional")
+                    Label("\(template.totalWorkingSets) sets", systemImage: "number")
+                    Label("~\(template.estimatedDurationMinutes) min", systemImage: "clock")
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+
+            // Start button
+            Button(action: onStart) {
+                Text(workout != nil ? "Start Workout" : "Choose Workout")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(AppSpacing.md)
+        .gradientCardStyle()
+    }
+
+    private func muscleGroupSummary(for template: Template) -> String {
+        let muscles = template.exercises
+            .compactMap { $0.exerciseLibraryItem }
+            .flatMap { $0.primaryMuscles }
+        let unique = Array(Set(muscles))
+        let names = unique.prefix(3).map { $0.rawValue.capitalized }
+        if unique.count > 3 {
+            return names.joined(separator: ", ") + " +\(unique.count - 3)"
+        }
+        return names.joined(separator: ", ")
+    }
+}
+
+// MARK: - No Program Fallback
+
+struct HeroWorkoutFallbackCard: View {
+    let onChooseProgram: () -> Void
+
+    var body: some View {
+        VStack(spacing: AppSpacing.md) {
+            Image(systemName: "figure.run")
+                .font(.system(size: 40))
+                .foregroundColor(.appTheme)
+
+            Text("No Active Program")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text("Start a program to see your next workout here")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button(action: onChooseProgram) {
+                Text("Browse Programs")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(AppSpacing.lg)
+        .cardStyle(hasBorder: true)
+    }
+}
+
+#Preview("With Workout") {
+    HeroWorkoutCard(
+        workout: MockProgramRepository.samplePrograms[0].currentWorkout,
+        template: MockTemplateRepository.sampleTemplates.first,
+        programProgress: 0.4,
+        onStart: {}
+    )
+    .padding()
+    .withDependencies(.preview)
+}
+
+#Preview("No Program") {
+    HeroWorkoutFallbackCard(onChooseProgram: {})
+        .padding()
+}

--- a/Nippardation/Views/Home/PlanDetailsSection.swift
+++ b/Nippardation/Views/Home/PlanDetailsSection.swift
@@ -1,0 +1,90 @@
+//
+//  PlanDetailsSection.swift
+//  Nippardation
+//
+//  Shows active program info and next workout on the home dashboard
+//
+
+import SwiftUI
+
+struct PlanDetailsSection: View {
+    let program: Program?
+    let nextWorkout: ProgramWorkout?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            SectionHeader(title: "Active Plan")
+
+            if let program {
+                NavigationLink(destination: ProgramDetailView(programServerId: program.serverId)) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                            Text(program.name)
+                                .font(.headline)
+                                .foregroundColor(.primary)
+
+                            HStack(spacing: AppSpacing.sm) {
+                                Label(program.frequencyString, systemImage: "calendar")
+                                Label(program.durationString, systemImage: "clock")
+                            }
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                            if !program.isIndefinite {
+                                ProgressView(value: program.progress)
+                                    .tint(.green)
+                                    .padding(.top, AppSpacing.xxs)
+                            }
+                        }
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(AppSpacing.md)
+                    .cardStyle()
+                }
+            } else {
+                NavigationLink(destination: ProgramListView()) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                            Text("No active plan")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+
+                            Text("Tap to browse programs")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(AppSpacing.md)
+                    .cardStyle(hasBorder: true)
+                }
+            }
+        }
+    }
+}
+
+#Preview("With Program") {
+    NavigationStack {
+        PlanDetailsSection(
+            program: MockProgramRepository.samplePrograms[0],
+            nextWorkout: MockProgramRepository.samplePrograms[0].currentWorkout
+        )
+        .padding()
+        .withDependencies(.preview)
+    }
+}
+
+#Preview("No Program") {
+    NavigationStack {
+        PlanDetailsSection(program: nil, nextWorkout: nil)
+            .padding()
+    }
+}

--- a/Nippardation/Views/Root/HistoryPlaceholderView.swift
+++ b/Nippardation/Views/Root/HistoryPlaceholderView.swift
@@ -1,0 +1,25 @@
+//
+//  HistoryPlaceholderView.swift
+//  Nippardation
+//
+//  Placeholder for the History tab (coming soon)
+//
+
+import SwiftUI
+
+struct HistoryPlaceholderView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "Coming Soon",
+            systemImage: "clock.arrow.circlepath",
+            description: Text("Your full workout history will appear here in a future update.")
+        )
+        .navigationTitle("History")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HistoryPlaceholderView()
+    }
+}

--- a/Nippardation/Views/Root/MainTabView.swift
+++ b/Nippardation/Views/Root/MainTabView.swift
@@ -1,0 +1,63 @@
+//
+//  MainTabView.swift
+//  Nippardation
+//
+//  Root view wrapping the authenticated experience in a 5-tab TabView
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    @EnvironmentObject private var authManager: AuthManager
+    @State private var selectedTab: AppTab = .home
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            NavigationStack {
+                HomeView()
+            }
+            .tag(AppTab.home)
+            .tabItem {
+                Label(AppTab.home.label, systemImage: AppTab.home.icon)
+            }
+
+            NavigationStack {
+                ProgramListView()
+            }
+            .tag(AppTab.programs)
+            .tabItem {
+                Label(AppTab.programs.label, systemImage: AppTab.programs.icon)
+            }
+
+            NavigationStack {
+                TemplateListView()
+            }
+            .tag(AppTab.templates)
+            .tabItem {
+                Label(AppTab.templates.label, systemImage: AppTab.templates.icon)
+            }
+
+            NavigationStack {
+                HistoryPlaceholderView()
+            }
+            .tag(AppTab.history)
+            .tabItem {
+                Label(AppTab.history.label, systemImage: AppTab.history.icon)
+            }
+
+            NavigationStack {
+                ProfilePlaceholderView()
+            }
+            .tag(AppTab.profile)
+            .tabItem {
+                Label(AppTab.profile.label, systemImage: AppTab.profile.icon)
+            }
+        }
+        .tint(Color.appTheme)
+    }
+}
+
+#Preview {
+    MainTabView()
+        .environmentObject(AuthManager.shared)
+}

--- a/Nippardation/Views/Root/ProfilePlaceholderView.swift
+++ b/Nippardation/Views/Root/ProfilePlaceholderView.swift
@@ -1,0 +1,68 @@
+//
+//  ProfilePlaceholderView.swift
+//  Nippardation
+//
+//  Profile tab with user info and sign out (relocated from HomeView toolbar)
+//
+
+import SwiftUI
+
+struct ProfilePlaceholderView: View {
+    @EnvironmentObject private var authManager: AuthManager
+    @State private var error: Error?
+    @State private var showErrorAlert = false
+
+    var body: some View {
+        List {
+            Section {
+                HStack(spacing: AppSpacing.md) {
+                    Image(systemName: "person.circle.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(.appTheme)
+
+                    VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                        Text(authManager.backendUser?.displayName ?? "User")
+                            .font(.headline)
+
+                        if let email = authManager.user?.email {
+                            Text(email)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .padding(.vertical, AppSpacing.xs)
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    signOut()
+                } label: {
+                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
+        }
+        .navigationTitle("Profile")
+        .alert("Sign Out Error", isPresented: $showErrorAlert) {
+            Button("OK") {}
+        } message: {
+            Text(error?.localizedDescription ?? "An unknown error occurred")
+        }
+    }
+
+    private func signOut() {
+        do {
+            try authManager.signOut()
+        } catch {
+            self.error = error
+            showErrorAlert = true
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfilePlaceholderView()
+            .environmentObject(AuthManager.shared)
+    }
+}


### PR DESCRIPTION
## Summary

- **HeroWorkoutCard**: Prominent card showing next workout from active program with circular progress ring, muscle group summary, exercise/set/duration pills, and "Start Workout" button. Falls back to `HeroWorkoutFallbackCard` when no active program
- **CircularProgressView**: Reusable ring progress indicator with configurable color, size, and line width
- **ActivityStatCards**: Horizontal scroll of `StatCard` components showing Workouts This Week, Total Volume (30d), and Weekly Consistency percentage
- **PlanDetailsSection**: Active program card with progress bar and NavigationLink to ProgramDetailView; "No active plan" fallback linking to ProgramListView
- **HomeView**: Complete layout rewrite — hero section, stat cards, volume chart, plan details, recent workouts — all using design system tokens
- **HomeViewModel**: Now loads active program via `ProgramRepository`, resolves next workout template, and computes weekly stats from `TrackedWorkout` data

## Context

PR3 of 10 in the UI revamp. Depends on PR1 (#17) for design system and PR2 (#18) for tab navigation. This completely redesigns the home screen from a flat list to a structured dashboard.

## Test plan

- [x] `xcodebuild build` passes
- [x] All unit tests pass
- [x] Home displays hero card with active program data
- [x] Home shows fallback card when no active program
- [x] Activity stat cards compute from completed workouts
- [x] Volume chart preserved and functional
- [x] Start/Resume workout FAB still works
- [x] Recent workouts section displays correctly
- [x] 523 lines total (well within 1000-line limit)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a large UI restructuring and new async dashboard loading/stats computation; could introduce state/update timing issues but does not touch auth/security-critical flows.
> 
> **Overview**
> Redesigns `HomeView` into a structured dashboard with a hero workout card, weekly activity stat cards, volume chart, active plan details, and a restyled recent workouts section, while preserving the start/resume workout flow via a floating action button.
> 
> Expands `HomeViewModel` to asynchronously load the active program/next workout (resolving templates when needed) and compute weekly/30-day workout stats from tracked workout history.
> 
> Updates the authenticated app entry to use a new 5-tab `MainTabView` (Home/Programs/Templates/History/Profile), moving sign-out/user info from the old Home toolbar into a new `ProfilePlaceholderView` and adding a `HistoryPlaceholderView`. Also simplifies `DashboardView` by removing an extra `NavigationStack` wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d3af69526d83977e560c95e8f2ddcc4a20a4d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->