### PR TITLE
PR8: Program wizard step 1 — basics and day selector

### DIFF
--- a/Nippardation/ViewModels/Programs/ProgramEditorViewModel.swift
+++ b/Nippardation/ViewModels/Programs/ProgramEditorViewModel.swift
@@ -19,6 +19,7 @@ final class ProgramEditorViewModel: ObservableObject {
     @Published var durationWeeks: Int? = nil
     @Published var workouts: [EditableWorkout] = []
     @Published var isIndefinite: Bool = true
+    @Published var selectedDays: Set<Int> = []
 
     @Published var isSaving = false
     @Published var isLoadingTemplates = false
@@ -58,6 +59,11 @@ final class ProgramEditorViewModel: ObservableObject {
         workouts.allSatisfy { $0.templateServerId != nil }
     }
 
+    /// Validates Step 1 of the wizard (name + days selected)
+    var isStep1Valid: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty && !selectedDays.isEmpty
+    }
+
     // MARK: - Initialization
 
     init(
@@ -93,6 +99,17 @@ final class ProgramEditorViewModel: ObservableObject {
             .dropFirst()
             .sink { [weak self] _ in
                 self?.updateWorkoutCount()
+            }
+            .store(in: &cancellables)
+
+        // Sync selectedDays count with daysPerWeek
+        $selectedDays
+            .dropFirst()
+            .sink { [weak self] days in
+                guard let self = self else { return }
+                if days.count != self.daysPerWeek {
+                    self.daysPerWeek = days.count
+                }
             }
             .store(in: &cancellables)
 

--- a/Nippardation/Views/Programs/DaySelectorGrid.swift
+++ b/Nippardation/Views/Programs/DaySelectorGrid.swift
@@ -1,0 +1,62 @@
+//
+//  DaySelectorGrid.swift
+//  Nippardation
+//
+//  Seven-button day selector for the program wizard
+//
+
+import SwiftUI
+
+struct DaySelectorGrid: View {
+    @Binding var selectedDays: Set<Int>
+
+    private let days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    var body: some View {
+        VStack(spacing: AppSpacing.sm) {
+            HStack(spacing: AppSpacing.xs) {
+                ForEach(0..<7, id: \.self) { index in
+                    dayButton(index: index)
+                }
+            }
+
+            Text("\(selectedDays.count) day\(selectedDays.count == 1 ? "" : "s") selected")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func dayButton(index: Int) -> some View {
+        let isSelected = selectedDays.contains(index)
+
+        return Button {
+            if isSelected {
+                selectedDays.remove(index)
+            } else {
+                selectedDays.insert(index)
+            }
+        } label: {
+            VStack(spacing: AppSpacing.xxs) {
+                Text(days[index])
+                    .font(.caption)
+                    .fontWeight(isSelected ? .semibold : .regular)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption2)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppSpacing.sm)
+            .background(isSelected ? Color.appTheme.opacity(0.15) : Color(.tertiarySystemBackground))
+            .foregroundColor(isSelected ? .appTheme : .primary)
+            .cornerRadius(AppCornerRadius.small)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    DaySelectorGrid(selectedDays: .constant([0, 2, 4]))
+        .padding()
+}

--- a/Nippardation/Views/Programs/ProgramListView.swift
+++ b/Nippardation/Views/Programs/ProgramListView.swift
@@ -28,7 +28,7 @@ struct ProgramListView: View {
             }
             .sheet(isPresented: $showCreateProgram) {
                 NavigationStack {
-                    ProgramEditorView()
+                    ProgramWizardView()
                 }
             }
             .alert("Delete Program", isPresented: $showDeleteConfirmation) {

--- a/Nippardation/Views/Programs/ProgramWizardStep1.swift
+++ b/Nippardation/Views/Programs/ProgramWizardStep1.swift
@@ -1,0 +1,105 @@
+//
+//  ProgramWizardStep1.swift
+//  Nippardation
+//
+//  Step 1 of the program wizard: basic info and schedule
+//
+
+import SwiftUI
+
+struct ProgramWizardStep1: View {
+    @ObservedObject var viewModel: ProgramEditorViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: AppSpacing.lg) {
+                // Step title
+                VStack(spacing: AppSpacing.xs) {
+                    Text("The Basics")
+                        .font(.title2)
+                        .fontWeight(.bold)
+
+                    Text("Name your program and set up the schedule")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                // Program name
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("Program Name")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    HStack(spacing: AppSpacing.sm) {
+                        Image(systemName: "pencil.line")
+                            .foregroundColor(.appTheme)
+
+                        TextField("e.g., PPL Hypertrophy", text: $viewModel.name)
+                            .textFieldStyle(.plain)
+                    }
+                    .padding(AppSpacing.sm)
+                    .background(Color(.tertiarySystemBackground))
+                    .cornerRadius(AppCornerRadius.medium)
+                }
+
+                // Duration
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Text("Duration")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    HStack(spacing: AppSpacing.md) {
+                        Toggle("", isOn: Binding(
+                            get: { !viewModel.isIndefinite },
+                            set: { viewModel.isIndefinite = !$0 }
+                        ))
+                        .labelsHidden()
+
+                        VStack(alignment: .leading) {
+                            Text(viewModel.isIndefinite ? "Ongoing" : "\(viewModel.durationWeeks ?? 8) Weeks")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Text(viewModel.isIndefinite ? "No end date" : "Fixed duration program")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+
+                        Spacer()
+                    }
+                    .padding(AppSpacing.sm)
+                    .cardStyle()
+
+                    if !viewModel.isIndefinite {
+                        Stepper(
+                            "Duration: \(viewModel.durationWeeks ?? 8) weeks",
+                            value: Binding(
+                                get: { viewModel.durationWeeks ?? 8 },
+                                set: { viewModel.durationWeeks = $0 }
+                            ),
+                            in: 1...52
+                        )
+                        .padding(AppSpacing.sm)
+                        .cardStyle()
+                    }
+                }
+
+                // Training days
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Text("Training Days")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    DaySelectorGrid(selectedDays: $viewModel.selectedDays)
+                        .padding(AppSpacing.sm)
+                        .cardStyle()
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+}
+
+#Preview {
+    ProgramWizardStep1(viewModel: ProgramEditorViewModel())
+        .withDependencies(.preview)
+}

--- a/Nippardation/Views/Programs/ProgramWizardView.swift
+++ b/Nippardation/Views/Programs/ProgramWizardView.swift
@@ -1,0 +1,119 @@
+//
+//  ProgramWizardView.swift
+//  Nippardation
+//
+//  Multi-step wizard for creating new programs
+//
+
+import SwiftUI
+
+struct ProgramWizardView: View {
+    @StateObject private var viewModel = ProgramEditorViewModel()
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var currentStep = 0
+    private let totalSteps = 3
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Step indicator
+            StepIndicator(totalSteps: totalSteps, currentStep: currentStep)
+                .padding(.top, AppSpacing.sm)
+                .padding(.bottom, AppSpacing.md)
+
+            // Step content
+            Group {
+                switch currentStep {
+                case 0:
+                    ProgramWizardStep1(viewModel: viewModel)
+                case 1:
+                    // Step 2: Schedule builder (PR9)
+                    Text("Step 2: Schedule — Coming in PR9")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case 2:
+                    // Step 3: Review (PR9)
+                    Text("Step 3: Review — Coming in PR9")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                default:
+                    EmptyView()
+                }
+            }
+
+            // Navigation buttons
+            HStack(spacing: AppSpacing.md) {
+                if currentStep > 0 {
+                    Button {
+                        withAnimation { currentStep -= 1 }
+                    } label: {
+                        Text("Back")
+                            .fontWeight(.medium)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                }
+
+                Button {
+                    if currentStep < totalSteps - 1 {
+                        withAnimation { currentStep += 1 }
+                    } else {
+                        viewModel.save()
+                    }
+                } label: {
+                    Text(currentStep < totalSteps - 1 ? "Continue" : "Create Program")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(!isCurrentStepValid)
+            }
+            .padding(AppSpacing.md)
+        }
+        .navigationTitle("New Program")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+        }
+        .onAppear {
+            viewModel.loadTemplates()
+        }
+        .onChange(of: viewModel.savedProgram) { _, newValue in
+            if newValue != nil { dismiss() }
+        }
+        .disabled(viewModel.isSaving)
+        .overlay {
+            if viewModel.isSaving {
+                ProgressView("Creating...")
+                    .padding()
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            }
+        }
+        .alert("Error", isPresented: .init(
+            get: { viewModel.error != nil },
+            set: { if !$0 { viewModel.clearError() } }
+        )) {
+            Button("OK") { viewModel.clearError() }
+        } message: {
+            Text(viewModel.error ?? "An unknown error occurred")
+        }
+    }
+
+    private var isCurrentStepValid: Bool {
+        switch currentStep {
+        case 0: return viewModel.isStep1Valid
+        case 1: return true // Step 2 validation in PR9
+        case 2: return viewModel.isValid
+        default: return false
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProgramWizardView()
+    }
+    .withDependencies(.preview)
+}

--- a/Nippardation/Views/Programs/StepIndicator.swift
+++ b/Nippardation/Views/Programs/StepIndicator.swift
@@ -1,0 +1,32 @@
+//
+//  StepIndicator.swift
+//  Nippardation
+//
+//  Dot-based step indicator for the program wizard
+//
+
+import SwiftUI
+
+struct StepIndicator: View {
+    let totalSteps: Int
+    let currentStep: Int
+
+    var body: some View {
+        HStack(spacing: AppSpacing.xs) {
+            ForEach(0..<totalSteps, id: \.self) { step in
+                Capsule()
+                    .fill(step <= currentStep ? Color.appTheme : Color.secondary.opacity(0.3))
+                    .frame(width: step == currentStep ? 24 : 8, height: 8)
+                    .animation(.spring(duration: 0.3), value: currentStep)
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: AppSpacing.lg) {
+        StepIndicator(totalSteps: 3, currentStep: 0)
+        StepIndicator(totalSteps: 3, currentStep: 1)
+        StepIndicator(totalSteps: 3, currentStep: 2)
+    }
+}


### PR DESCRIPTION
## Summary
- **New**: `ProgramWizardView` — multi-step wizard container with step indicator and nav buttons
- **New**: `ProgramWizardStep1` — program name, duration toggle, and day selector
- **New**: `StepIndicator` — animated dot-based step indicator
- **New**: `DaySelectorGrid` — 7-day toggle grid (Mon-Sun)
- **Modified**: `ProgramEditorViewModel` — added `selectedDays`, `isStep1Valid`, days↔daysPerWeek sync
- **Modified**: `ProgramListView` — new program sheet routes to wizard instead of form

## Test plan
- [ ] Step indicator animates between steps
- [ ] Day selector toggles correctly and shows count
- [ ] Continue button disabled when name empty or no days selected
- [ ] Cancel dismisses wizard
- [ ] Existing program editing still uses the form

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new program-creation flow and new state syncing (`selectedDays` ↔ `daysPerWeek`), which could impact validation and workout-count behavior, but changes are isolated to program creation UI/view model.
> 
> **Overview**
> Adds a new multi-step `ProgramWizardView` for creating programs, including a `StepIndicator` and step navigation with step-level validation/disablement.
> 
> Implements Step 1 UI (`ProgramWizardStep1`) with program name, duration (ongoing vs fixed weeks), and a new 7-day toggle control (`DaySelectorGrid`) that tracks selected training days.
> 
> Updates `ProgramEditorViewModel` to store `selectedDays`, provide `isStep1Valid`, and keep `daysPerWeek` in sync with the number of selected days; `ProgramListView` now launches the wizard instead of `ProgramEditorView` when creating a new program (editing still uses the existing form).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64cd78bf2eaa2cc9461b8e262eb7c4e6b3ea1f30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->