### PR TITLE
PR9: Program wizard steps 2 & 3 — schedule and review

### DIFF
--- a/Nippardation/ViewModels/Programs/ProgramEditorViewModel.swift
+++ b/Nippardation/ViewModels/Programs/ProgramEditorViewModel.swift
@@ -20,6 +20,7 @@ final class ProgramEditorViewModel: ObservableObject {
     @Published var workouts: [EditableWorkout] = []
     @Published var isIndefinite: Bool = true
     @Published var selectedDays: Set<Int> = []
+    @Published var restDays: Set<Int> = []
 
     @Published var isSaving = false
     @Published var isLoadingTemplates = false
@@ -62,6 +63,15 @@ final class ProgramEditorViewModel: ObservableObject {
     /// Validates Step 1 of the wizard (name + days selected)
     var isStep1Valid: Bool {
         !name.trimmingCharacters(in: .whitespaces).isEmpty && !selectedDays.isEmpty
+    }
+
+    /// Validates Step 2 of the wizard (all non-rest days have templates)
+    var isStep2Valid: Bool {
+        for (index, workout) in workouts.enumerated() {
+            if restDays.contains(index) { continue }
+            if workout.templateServerId == nil { return false }
+        }
+        return !workouts.isEmpty
     }
 
     // MARK: - Initialization
@@ -178,6 +188,19 @@ final class ProgramEditorViewModel: ObservableObject {
         // Renumber
         for i in 0..<workouts.count {
             workouts[i].dayNumber = i
+        }
+    }
+
+    /// Toggles a workout day as a rest day
+    func toggleRestDay(at index: Int) {
+        guard index >= 0 && index < workouts.count else { return }
+        if restDays.contains(index) {
+            restDays.remove(index)
+        } else {
+            restDays.insert(index)
+            // Clear template assignment when marking as rest
+            workouts[index].templateServerId = nil
+            workouts[index].templateName = nil
         }
     }
 

--- a/Nippardation/Views/Programs/DayScheduleCard.swift
+++ b/Nippardation/Views/Programs/DayScheduleCard.swift
@@ -1,0 +1,117 @@
+//
+//  DayScheduleCard.swift
+//  Nippardation
+//
+//  Day card for the weekly schedule builder in the program wizard
+//
+
+import SwiftUI
+
+struct DayScheduleCard: View {
+    let dayNumber: Int
+    let dayLabel: String
+    let templateName: String?
+    let exerciseCount: Int?
+    let isRest: Bool
+    let onSelectTemplate: () -> Void
+    let onToggleRest: () -> Void
+
+    private let dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    var body: some View {
+        HStack(spacing: AppSpacing.sm) {
+            // Day circle
+            VStack(spacing: AppSpacing.xxs) {
+                Text(dayNumber < dayNames.count ? dayNames[dayNumber] : "Day")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+
+                Circle()
+                    .fill(circleColor)
+                    .frame(width: 32, height: 32)
+                    .overlay(
+                        Image(systemName: circleIcon)
+                            .font(.caption)
+                            .foregroundColor(.white)
+                    )
+            }
+
+            // Content
+            VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                if isRest {
+                    Text("Rest Day")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                } else if let name = templateName {
+                    Text(name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+
+                    if let count = exerciseCount {
+                        Text("\(count) exercises")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Button(action: onSelectTemplate) {
+                        Text("Select Template")
+                            .font(.subheadline)
+                            .foregroundColor(.appTheme)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Rest toggle
+            Button {
+                onToggleRest()
+            } label: {
+                Image(systemName: isRest ? "moon.fill" : "moon")
+                    .foregroundColor(isRest ? .purple : .secondary)
+            }
+        }
+        .padding(AppSpacing.sm)
+        .background(isRest ? Color(.tertiarySystemBackground) : Color(.secondarySystemBackground))
+        .cornerRadius(AppCornerRadius.medium)
+        .onTapGesture {
+            if !isRest && templateName == nil {
+                onSelectTemplate()
+            }
+        }
+    }
+
+    private var circleColor: Color {
+        if isRest { return .gray }
+        if templateName != nil { return .appTheme }
+        return .secondary.opacity(0.5)
+    }
+
+    private var circleIcon: String {
+        if isRest { return "moon.fill" }
+        if templateName != nil { return "checkmark" }
+        return "plus"
+    }
+}
+
+#Preview {
+    VStack(spacing: AppSpacing.sm) {
+        DayScheduleCard(
+            dayNumber: 0, dayLabel: "Day 1", templateName: "Push Day",
+            exerciseCount: 7, isRest: false,
+            onSelectTemplate: {}, onToggleRest: {}
+        )
+        DayScheduleCard(
+            dayNumber: 1, dayLabel: "Day 2", templateName: nil,
+            exerciseCount: nil, isRest: false,
+            onSelectTemplate: {}, onToggleRest: {}
+        )
+        DayScheduleCard(
+            dayNumber: 2, dayLabel: "Day 3", templateName: nil,
+            exerciseCount: nil, isRest: true,
+            onSelectTemplate: {}, onToggleRest: {}
+        )
+    }
+    .padding()
+}

--- a/Nippardation/Views/Programs/ProgramWizardStep2.swift
+++ b/Nippardation/Views/Programs/ProgramWizardStep2.swift
@@ -1,0 +1,105 @@
+//
+//  ProgramWizardStep2.swift
+//  Nippardation
+//
+//  Step 2 of the program wizard: weekly schedule builder
+//
+
+import SwiftUI
+
+struct ProgramWizardStep2: View {
+    @ObservedObject var viewModel: ProgramEditorViewModel
+    @State private var selectedWorkoutIndex: Int?
+    @State private var showTemplatePicker = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: AppSpacing.lg) {
+                // Step title
+                VStack(spacing: AppSpacing.xs) {
+                    Text("Build Your Schedule")
+                        .font(.title2)
+                        .fontWeight(.bold)
+
+                    Text("Assign templates to each training day")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                // Progress
+                progressBar
+
+                // Day cards
+                VStack(spacing: AppSpacing.sm) {
+                    ForEach(Array(viewModel.workouts.enumerated()), id: \.element.id) { index, workout in
+                        let isRest = viewModel.restDays.contains(index)
+                        DayScheduleCard(
+                            dayNumber: dayNumberForWorkout(index),
+                            dayLabel: workout.dayLabel,
+                            templateName: workout.templateName,
+                            exerciseCount: exerciseCount(for: workout),
+                            isRest: isRest,
+                            onSelectTemplate: {
+                                selectedWorkoutIndex = index
+                                showTemplatePicker = true
+                            },
+                            onToggleRest: {
+                                viewModel.toggleRestDay(at: index)
+                            }
+                        )
+                    }
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+        .sheet(isPresented: $showTemplatePicker) {
+            TemplateSelectorSheet(
+                templates: viewModel.availableTemplates,
+                isLoading: viewModel.isLoadingTemplates,
+                onSelect: { template in
+                    if let index = selectedWorkoutIndex {
+                        viewModel.setTemplate(template, for: index)
+                    }
+                }
+            )
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var progressBar: some View {
+        let assigned = viewModel.workouts.enumerated().filter { index, workout in
+            viewModel.restDays.contains(index) || workout.templateServerId != nil
+        }.count
+        let total = viewModel.workouts.count
+
+        return VStack(spacing: AppSpacing.xxs) {
+            ProgressView(value: Double(assigned), total: Double(max(total, 1)))
+                .tint(.appTheme)
+
+            Text("\(assigned)/\(total) days configured")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func dayNumberForWorkout(_ index: Int) -> Int {
+        let sortedDays = viewModel.selectedDays.sorted()
+        if index < sortedDays.count {
+            return sortedDays[index]
+        }
+        return index
+    }
+
+    private func exerciseCount(for workout: ProgramEditorViewModel.EditableWorkout) -> Int? {
+        guard let templateId = workout.templateServerId else { return nil }
+        return viewModel.availableTemplates.first { $0.serverId == templateId }?.exerciseCount
+    }
+}
+
+#Preview {
+    ProgramWizardStep2(viewModel: ProgramEditorViewModel())
+        .withDependencies(.preview)
+}

--- a/Nippardation/Views/Programs/ProgramWizardStep3.swift
+++ b/Nippardation/Views/Programs/ProgramWizardStep3.swift
@@ -1,0 +1,170 @@
+//
+//  ProgramWizardStep3.swift
+//  Nippardation
+//
+//  Step 3 of the program wizard: review and create
+//
+
+import SwiftUI
+
+struct ProgramWizardStep3: View {
+    @ObservedObject var viewModel: ProgramEditorViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: AppSpacing.lg) {
+                // Step title
+                VStack(spacing: AppSpacing.xs) {
+                    Text("Review Your Program")
+                        .font(.title2)
+                        .fontWeight(.bold)
+
+                    Text("Make sure everything looks good")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                // Program summary
+                summaryCard
+
+                // Schedule overview
+                scheduleCard
+
+                // Stats
+                statsRow
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+
+    // MARK: - Summary Card
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            SectionHeader(title: "Program")
+
+            VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                Text(viewModel.name)
+                    .font(.headline)
+
+                if !viewModel.description.isEmpty {
+                    Text(viewModel.description)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                HStack(spacing: AppSpacing.md) {
+                    PillBadge(
+                        text: "\(viewModel.daysPerWeek) days/week",
+                        color: .appTheme,
+                        style: .tinted
+                    )
+
+                    if viewModel.isIndefinite {
+                        PillBadge(text: "Ongoing", color: .green, style: .tinted)
+                    } else {
+                        PillBadge(
+                            text: "\(viewModel.durationWeeks ?? 8) weeks",
+                            color: .purple,
+                            style: .tinted
+                        )
+                    }
+                }
+            }
+        }
+        .padding(AppSpacing.md)
+        .cardStyle()
+    }
+
+    // MARK: - Schedule Card
+
+    private var scheduleCard: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            SectionHeader(title: "Weekly Schedule")
+
+            ForEach(Array(viewModel.workouts.enumerated()), id: \.element.id) { index, workout in
+                let isRest = viewModel.restDays.contains(index)
+                HStack {
+                    Text("Day \(index + 1)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(width: 44, alignment: .leading)
+
+                    if isRest {
+                        Text("Rest Day")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    } else {
+                        Text(workout.templateName ?? "Unassigned")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: isRest ? "moon.fill" : "checkmark.circle.fill")
+                        .foregroundColor(isRest ? .purple : .green)
+                        .font(.caption)
+                }
+                .padding(.vertical, AppSpacing.xxs)
+
+                if index < viewModel.workouts.count - 1 {
+                    Divider()
+                }
+            }
+        }
+        .padding(AppSpacing.md)
+        .cardStyle()
+    }
+
+    // MARK: - Stats Row
+
+    private var statsRow: some View {
+        HStack(spacing: AppSpacing.sm) {
+            statItem(value: "\(trainingDayCount)", label: "Training Days")
+            statItem(value: "\(restDayCount)", label: "Rest Days")
+            statItem(value: "\(totalExercises)", label: "Exercises")
+        }
+    }
+
+    private func statItem(value: String, label: String) -> some View {
+        VStack(spacing: AppSpacing.xxs) {
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(AppSpacing.sm)
+        .cardStyle()
+    }
+
+    // MARK: - Computed
+
+    private var trainingDayCount: Int {
+        viewModel.workouts.count - restDayCount
+    }
+
+    private var restDayCount: Int {
+        viewModel.restDays.count
+    }
+
+    private var totalExercises: Int {
+        var count = 0
+        for (index, workout) in viewModel.workouts.enumerated() {
+            if viewModel.restDays.contains(index) { continue }
+            if let templateId = workout.templateServerId,
+               let template = viewModel.availableTemplates.first(where: { $0.serverId == templateId }) {
+                count += template.exerciseCount
+            }
+        }
+        return count
+    }
+}
+
+#Preview {
+    ProgramWizardStep3(viewModel: ProgramEditorViewModel())
+        .withDependencies(.preview)
+}

--- a/Nippardation/Views/Programs/ProgramWizardView.swift
+++ b/Nippardation/Views/Programs/ProgramWizardView.swift
@@ -27,13 +27,9 @@ struct ProgramWizardView: View {
                 case 0:
                     ProgramWizardStep1(viewModel: viewModel)
                 case 1:
-                    // Step 2: Schedule builder (PR9)
-                    Text("Step 2: Schedule — Coming in PR9")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    ProgramWizardStep2(viewModel: viewModel)
                 case 2:
-                    // Step 3: Review (PR9)
-                    Text("Step 3: Review — Coming in PR9")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    ProgramWizardStep3(viewModel: viewModel)
                 default:
                     EmptyView()
                 }
@@ -104,7 +100,7 @@ struct ProgramWizardView: View {
     private var isCurrentStepValid: Bool {
         switch currentStep {
         case 0: return viewModel.isStep1Valid
-        case 1: return true // Step 2 validation in PR9
+        case 1: return viewModel.isStep2Valid
         case 2: return viewModel.isValid
         default: return false
         }

--- a/Nippardation/Views/Programs/TemplateSelectorSheet.swift
+++ b/Nippardation/Views/Programs/TemplateSelectorSheet.swift
@@ -1,0 +1,76 @@
+//
+//  TemplateSelectorSheet.swift
+//  Nippardation
+//
+//  Simplified template picker for the program wizard
+//
+
+import SwiftUI
+
+struct TemplateSelectorSheet: View {
+    let templates: [Template]
+    let isLoading: Bool
+    let onSelect: (Template) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView("Loading templates...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if templates.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Templates", systemImage: "doc.text")
+                    } description: {
+                        Text("Create a template first to use in your program")
+                    }
+                } else {
+                    List(templates) { template in
+                        Button {
+                            onSelect(template)
+                            dismiss()
+                        } label: {
+                            HStack(spacing: AppSpacing.sm) {
+                                IconCircle(
+                                    icon: "doc.text.fill",
+                                    color: .appTheme,
+                                    size: 36
+                                )
+
+                                VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+                                    Text(template.name)
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(.primary)
+
+                                    Text("\(template.exerciseCount) exercises · \(template.totalWorkingSets) sets")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+
+                                Spacer()
+                            }
+                        }
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("Select Template")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    TemplateSelectorSheet(
+        templates: MockTemplateRepository.sampleTemplates,
+        isLoading: false,
+        onSelect: { _ in }
+    )
+}


### PR DESCRIPTION
## Summary
- **New**: `ProgramWizardStep2` — weekly schedule builder with day cards, template assignment, rest day toggles, progress bar
- **New**: `ProgramWizardStep3` — review summary with program details, schedule overview, aggregate stats
- **New**: `DayScheduleCard` — day card with template info, rest toggle, visual states
- **New**: `TemplateSelectorSheet` — simplified template picker for wizard context
- **Modified**: `ProgramEditorViewModel` — added `restDays`, `isStep2Valid`, `toggleRestDay()`
- **Modified**: `ProgramWizardView` — wired up steps 2 and 3, updated validation

## Test plan
- [ ] Template assignment per day via sheet
- [ ] Rest day toggle clears template assignment
- [ ] Progress bar updates as days are configured
- [ ] Review step shows accurate totals
- [ ] "Create Program" saves and dismisses wizard
- [ ] Back/Continue navigation between all 3 steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new wizard UI flows and changes validation/state around template assignment (including rest-day behavior), which could affect program creation/saving if edge cases are missed.
> 
> **Overview**
> Completes the program creation wizard by implementing **Step 2 (schedule builder)** and **Step 3 (review)**, replacing the previous placeholder screens.
> 
> Step 2 lets users assign a workout template per day via a new `TemplateSelectorSheet`, mark days as *rest* via `DayScheduleCard`, and shows configuration progress; Step 3 summarizes program details, renders the weekly schedule (including rest days), and computes aggregate stats (training/rest days, total exercises).
> 
> `ProgramEditorViewModel` now tracks `restDays`, clears template assignments when toggling rest, and enforces step-level validation via `isStep2Valid`, which is wired into `ProgramWizardView` navigation/enablement logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 856c1caa085721791fa910dac5d506d2c39fda8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->