### PR TITLE
Fix program detail blank screen and polish UI

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,544 +1,197 @@
-# iOS Pre-PR Submission Checklist
+# Deep Code Audit — Pre-PR Submission
 
 ## Purpose
-Ruthlessly thorough verification that code is production-ready before opening a PR. This is the FINAL gate before submission. If ANY check fails, DO NOT open the PR.
+Automated deep-dive code review that catches real bugs before they hit PR review. This replaces surface-level checklists with the same exhaustive file-by-file analysis that catches nil guard bugs, force unwraps, race conditions, and code smell.
 
-## Execution Order
-
-This checklist MUST be executed in order. Do not skip steps. Do not proceed if any step fails.
+**This is NOT a checklist to skim. This is an execution plan. Run it.**
 
 ---
 
-## 1. Branch Verification
+## Phase 1: Scope the Diff
 
-**Check current branch state**
+Identify every file changed in this PR against the base branch.
+
 ```bash
-# Verify you're not on main
-current_branch=$(git branch --show-current)
-if [ "$current_branch" = "main" ]; then
-    echo "ERROR: Cannot submit PR from main branch"
-    exit 1
-fi
+# Get the base branch (usually develop)
+git diff develop...HEAD --stat
 
-# Verify branch is up to date with remote
-git fetch origin
-LOCAL=$(git rev-parse @)
-REMOTE=$(git rev-parse @{u})
-if [ $LOCAL != $REMOTE ]; then
-    echo "ERROR: Branch out of sync with remote. Push or pull required."
-    exit 1
-fi
+# Get the full list of changed files
+git diff develop...HEAD --name-only
 ```
 
-**Verify commit messages**
-- All commits have descriptive messages (not "wip", "fix", "update")
-- Commits are logical units of work
-- No merge commits (should be rebased)
+Categorize changed files into two groups:
+- **View files**: Any file in `Views/`, `Home/HomeView.swift`, `Exercise/` that contains SwiftUI views
+- **Non-view files**: Services, ViewModels, Models, Mappers, Extensions, DesignSystem, Tests, Mocks
 
 ---
 
-## 2. Code Compilation
+## Phase 2: Deep Audit (Parallel Agents)
 
-**Full clean build**
-```bash
-# Clean build folder
-xcodebuild clean -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15'
+Launch TWO parallel audit agents. Each agent must READ EVERY changed file in its group — no skipping, no sampling. Each agent produces a ranked list of every issue found.
 
-# Build for simulator
-xcodebuild build -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15' -quiet
+### Agent 1: View Files Audit
 
-# Build for device (if applicable)
-xcodebuild build -scheme Nippardation -destination 'generic/platform=iOS' -quiet
-```
+Read every changed view file. For EACH file, check for ALL of the following:
 
-**Build verification**
-- [ ] No compilation errors
-- [ ] No warnings (zero-warning policy)
-- [ ] No deprecated API usage
-- [ ] All asset references resolve
-- [ ] All string localizations exist
+**Crash Vectors**
+- Force unwraps (`!`) — every single one, even in previews
+- Unsafe array indexing without bounds checks (including negative index checks)
+- Missing nil guards that lead to incorrect behavior
+
+**Loading State Bugs**
+- Views that show "no data" / empty state messages BEFORE data has loaded (must check `isLoading` before showing empty state)
+- Views that check `.isEmpty` on `onAppear` without a `hasLoaded` flag (causes redundant fetches when data is genuinely empty)
+- Missing `ProgressView` for initial load states
+
+**SwiftUI Antipatterns**
+- Views presented in `.sheet()` or `.fullScreenCover()` that use `.navigationTitle` / `.toolbar` without being wrapped in `NavigationStack`
+- `.fullScreenCover` / `.sheet` that can show blank content if the bound data is nil (race condition)
+- `@ObservedObject` used with singleton default values (should be `@EnvironmentObject` or `let`)
+- Sheet/cover modifiers attached to inner views instead of the outermost container
+- Potential double-dismiss issues in nested navigation/sheet flows
+- Missing data reload after edit sheet dismissal (`onDismiss` handler)
+
+**Design System Compliance**
+- Magic numbers for spacing instead of `AppSpacing` constants
+- Magic numbers for corner radius instead of `AppCornerRadius` constants
+- Hardcoded colors that should use design tokens
+- `RelativeDateTimeFormatter` or other expensive formatters created inside computed properties (should be `static let`)
+
+**Code Smell**
+- Business logic in View structs (belongs in ViewModel)
+- Duplicated view builders across multiple files (should be extracted to reusable components)
+- Duplicated error alert boilerplate (should be a view modifier)
+- Free functions in global scope (should be extensions or static methods)
+- Non-deterministic `String.hashValue` used for visual elements (not stable across launches)
+
+**Data Integrity**
+- Silent fallback defaults that mask missing data (e.g., defaulting to `.chest` muscle group, defaulting `nil` notes to "Failure")
+- Optional chaining that silently drops important information
+
+### Agent 2: Non-View Files Audit
+
+Read every changed non-view file. For EACH file, check for ALL of the following:
+
+**Crash Vectors**
+- Force unwraps (`!`) in production code — `URLComponents(...)!`, `as!`, `cursor!`
+- Missing nil guards in decode chains (e.g., `APIEnvelope` with all-optional fields succeeding decode on any JSON, returning `nil` data without falling through to fallback decoders)
+- Force unwraps in test helpers (`MockURLProtocol`, etc.) that crash entire test suite on failure
+
+**Code Duplication**
+- Identical private types across files (e.g., `APIEnvelope` duplicated in two services)
+- Identical helper methods across files (e.g., `decodeFailure`, `parseDate`)
+- Identical structural patterns that should be generic helpers
+- `ISO8601DateFormatter()` or other formatters created repeatedly instead of shared
+
+**Thread Safety**
+- `@MainActor`-isolated properties read from `@Sendable` closures without capturing first
+- `@unchecked Sendable` on classes with mutable `var` properties and no synchronization
+- `withCheckedContinuation` that can hang if the task is cancelled before `resume()` is called
+- Redundant `await MainActor.run {}` inside already-`@MainActor` classes (use `TaskManager.runOnMain` if available)
+
+**Decoding Safety**
+- `try?` decode chains that silently discard the actual error from the correct format, making debugging impossible
+- Optional DTO fields (e.g., `exercises: [DTO]?`) that silently become empty arrays in domain models — consumers can't distinguish "not loaded" from "actually empty"
+- Date parsing that silently defaults to `Date()` on malformed input
+
+**Error Handling Consistency**
+- ViewModels that swallow errors silently vs. ones that set `self.error` — should be consistent
+- Template/data loading failures silently ignored via `try?` without any user indication
+- Error types that wrap decode errors as `.unknown` (loses error specificity)
+
+**Model Safety**
+- `Equatable`/`Hashable` that only compare `id` — SwiftUI won't detect property changes for re-render
+- Computed properties (e.g., `progress`) that don't guard against empty collections before doing math
+- Missing `final class` on ViewModels (inconsistent, allows unintended subclassing)
+
+**Memory**
+- `TaskManager` or similar that stores completed tasks indefinitely without cleanup
+- Retain cycle potential in closures (verify `[weak self]` usage)
 
 ---
 
-## 3. Code Quality & Style
+## Phase 3: Triage and Fix
 
-**SwiftLint**
-```bash
-# Run SwiftLint with strict rules
-swiftlint lint --strict --quiet
+After both agents report, consolidate all issues into a single ranked list:
 
-# If violations exist, show them
-swiftlint lint
-```
+**Severity Levels:**
+- **HIGH**: Will crash, hang, or show blank/broken UI in production
+- **MEDIUM**: Incorrect behavior, stale data, misleading UI, thread safety risk
+- **LOW**: Code smell, duplication, inconsistency, performance (non-blocking)
 
-**Manual code quality checks**
-- [ ] No force-unwraps without explicit documented reason
-- [ ] No force-try without proper justification
-- [ ] No force casts (as! operator)
-- [ ] No hardcoded strings (use localization)
-- [ ] No magic numbers (use named constants)
-- [ ] No commented-out code blocks
-- [ ] No `print()` statements (use proper logging)
-- [ ] No TODO/FIXME comments (create issues instead)
-- [ ] Proper access control (internal by default, public only when needed)
-- [ ] No retain cycles (check weak/unowned references)
+**Fix order:**
+1. ALL HIGH issues — no exceptions
+2. ALL MEDIUM issues — these are what external reviewers flag
+3. LOW issues — fix what's reasonable without scope creep
 
-**Architecture compliance**
-- [ ] MVVM structure maintained (no business logic in views)
-- [ ] Single Responsibility Principle followed
-- [ ] Dependencies properly injected (no singletons unless justified)
-- [ ] Protocols used for abstraction where appropriate
-- [ ] No massive view controllers (>300 lines)
-- [ ] No massive view models (>400 lines)
+For each fix:
+- State the exact file, line number, and what's wrong
+- Apply the fix
+- Move to the next issue
+
+Do NOT batch-read files you've already read. Do NOT re-audit after fixes. Fix everything in one pass.
 
 ---
 
-## 4. Test Suite Execution
+## Phase 4: Build and Test
 
-**Run the testing skill first**
 ```bash
-# If tests don't exist or fail, invoke the testing skill
-# This should add/update tests and verify they pass
-```
+# Build
+xcodebuild -project Nippardation.xcodeproj -scheme Nippardation -sdk iphonesimulator build
 
-**Full test suite**
-```bash
 # Run all unit tests
-xcodebuild test -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15' -only-testing:NippardationTests
+xcodebuild test -project Nippardation.xcodeproj -scheme Nippardation \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.5' \
+  -only-testing:NippardationTests
 ```
 
-**Test verification**
-- [ ] All tests pass
-- [ ] No skipped tests
-- [ ] No flaky tests (run twice if suspicious)
-- [ ] Test coverage meets minimums:
-  - New ViewModels: 90%+
-  - New Services/Repositories: 85%+
-  - New Models: 80%+
-- [ ] No tests with sleep() or arbitrary delays
-- [ ] All async tests properly use expectations or async/await
+Both MUST pass. If build fails, fix and rebuild. If tests fail, fix and rerun.
 
 ---
 
-## 5. Security Audit
-
-**API Keys & Secrets**
-```bash
-# Check for exposed secrets
-grep -r "API_KEY" --include="*.swift" .
-grep -r "api_key" --include="*.swift" .
-grep -r "secret" --include="*.swift" .
-grep -r "password" --include="*.swift" .
-grep -r "token" --include="*.swift" .
-```
-
-**Security checklist**
-- [ ] No API keys hardcoded in source
-- [ ] No secrets in git history
-- [ ] Keychain used for sensitive data
-- [ ] HTTPS enforced for all network calls
-- [ ] Certificate pinning implemented (if required)
-- [ ] User input properly validated/sanitized
-- [ ] SQL injection prevented (parameterized queries)
-- [ ] XSS prevention in web views
-
-**Data protection**
-- [ ] User data encrypted at rest
-- [ ] Sensitive data not logged
-- [ ] Proper error messages (no internal details exposed)
-- [ ] Authentication tokens refreshed properly
-- [ ] Biometric authentication working correctly
-
----
-
-## 6. Memory & Performance
-
-**Memory leaks**
-```bash
-# Run with Instruments if significant memory changes
-# Manually verify in Xcode Memory Graph Debugger
-```
-
-**Performance checks**
-- [ ] No synchronous operations on main thread
-- [ ] Images properly sized/optimized
-- [ ] Large lists use lazy loading
-- [ ] Network requests properly cancelled on view dismissal
-- [ ] No memory leaks in view controllers
-- [ ] Combine subscriptions properly cancelled
-
-**Startup performance**
-- [ ] App launch time < 2 seconds
-- [ ] Initial view appears quickly
-- [ ] No blocking operations in application:didFinishLaunching
-
----
-
-## 7. UI/UX Verification
-
-**Build and run manually**
-```bash
-# Launch app on simulator
-xcodebuild build -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15'
-# Then manually open simulator and run app
-```
-
-**Visual verification**
-- [ ] UI renders correctly on iPhone SE (smallest screen)
-- [ ] UI renders correctly on iPhone 15 Pro Max (largest screen)
-- [ ] Dark mode works correctly
-- [ ] Safe area insets respected
-- [ ] Navigation flows work as expected
-- [ ] All animations smooth (60fps)
-- [ ] No visual glitches or layout issues
-- [ ] Loading states display properly
-- [ ] Error states display properly
-- [ ] Empty states display properly
-
-**Accessibility (manual verification)**
-- [ ] VoiceOver labels present and accurate
-- [ ] Dynamic Type support
-- [ ] Sufficient color contrast
-- [ ] Interactive elements minimum 44pt tap target
-- [ ] Focus order logical
-
----
-
-## 8. Data & State Management
-
-**Persistence verification**
-- [ ] Data saves correctly
-- [ ] Data loads correctly
-- [ ] Database migrations work (test fresh install + upgrade)
-- [ ] Core Data relationships intact
-- [ ] No data loss scenarios
-
-**State management**
-- [ ] App state persists across backgrounds
-- [ ] Navigation state properly managed
-- [ ] No inconsistent states possible
-- [ ] Race conditions handled
-- [ ] Optimistic updates work correctly
-
----
-
-## 9. Error Handling
-
-**Error scenarios**
-- [ ] Network failures handled gracefully
-- [ ] Offline mode works (if applicable)
-- [ ] Invalid data handled without crashes
-- [ ] User-facing error messages are clear and actionable
-- [ ] Errors logged appropriately for debugging
-- [ ] Recovery actions provided where possible
-- [ ] Errors in ViewModels are displayed to users (via alerts, toasts, etc.)
-- [ ] Async operation failures don't leave UI in broken state
-
-**Edge cases**
-- [ ] Empty data sets handled
-- [ ] Maximum data sets handled
-- [ ] Rapid user interactions handled
-- [ ] Interrupted operations handled
-- [ ] Background/foreground transitions handled
-
----
-
-## 9.5. Crash Prevention (CRITICAL)
-
-**This section catches crashes that would take down the app in production. Review CAREFULLY.**
-
-**Forbidden crash-inducing patterns**
-```bash
-# Search for preconditions and assertions (should be removed or have fallbacks)
-grep -rn "precondition\(" --include="*.swift" .
-grep -rn "preconditionFailure\(" --include="*.swift" .
-grep -rn "fatalError\(" --include="*.swift" .
-grep -rn "assert\(" --include="*.swift" .
-grep -rn "assertionFailure\(" --include="*.swift" .
-```
-
-**Precondition and assertion checklist**
-- [ ] NO `precondition()` calls in production code (crashes in release builds)
-- [ ] NO `preconditionFailure()` calls in production code
-- [ ] `fatalError()` only used in truly unrecoverable situations (Core Data model init, required init)
-- [ ] `assert()` only used for debug-time invariant checking (safe in release)
-- [ ] `assertionFailure()` only used for debug-time impossible states
-
-**Force unwrap safety**
-```bash
-# Find force unwraps (! operator)
-grep -rn "!\." --include="*.swift" .
-grep -rn "!\[" --include="*.swift" .
-grep -rn "as!" --include="*.swift" .
-```
-
-- [ ] NO force unwraps (the ! operator) without documented safety guarantee
-- [ ] NO force casts (as! operator) without proven type safety
-- [ ] All force unwraps on constants (URLs, UUIDs) are verified at compile-time
-- [ ] Optional binding (`if let`, `guard let`) used instead of force unwrap
-
-**Array bounds safety**
-```bash
-# Find array subscript access patterns
-grep -rn "\[index\]" --include="*.swift" .
-grep -rn "\[i\]" --include="*.swift" .
-```
-
-- [ ] All array access has bounds checking (or uses safe methods like `.first`, `.last`)
-- [ ] `indices.contains(index)` or `guard index >= 0 && index < array.count` before access
-- [ ] ForEach with indices uses enumerated() pattern safely
-- [ ] SwiftUI Bindings to arrays check bounds before access (especially when array can shrink)
-- [ ] No array access after potential modification without re-validation
-
-**Empty collection edge cases**
-- [ ] .first force unwrap never used (use .first with optional handling)
-- [ ] .last force unwrap never used (use .last with optional handling)
-- [ ] Empty arrays handled gracefully (show empty state, not crash)
-- [ ] Division by `count` checks for zero first
-- [ ] randomElement() force unwrap not used (returns optional)
-
-**Optional chaining patterns**
-- [ ] Computed properties return optionals when data may not exist
-- [ ] Callers handle nil cases from optional-returning methods
-- [ ] No assumption that optional will "always" have a value
-
-**SwiftUI-specific crash vectors**
-- [ ] Binding getters/setters have bounds checks for array indices
-- [ ] State mutations don't happen during view body evaluation
-- [ ] Sheet/NavigationLink destinations don't assume data exists
-- [ ] ForEach with dynamic data uses stable identifiers
-
-**Concurrency safety**
-- [ ] No race conditions between array modifications and reads
-- [ ] MainActor isolation for UI state mutations
-- [ ] Task cancellation doesn't leave state in inconsistent condition
-
-**Example fixes for common issues:**
-
-```swift
-// BAD: Will crash if array is empty
-var currentItem: Item {
-    precondition(!items.isEmpty, "Items should not be empty")
-    return items[currentIndex]
-}
-
-// GOOD: Returns optional, callers handle nil
-var currentItem: Item? {
-    guard currentIndex >= 0 && currentIndex < items.count else { return nil }
-    return items[currentIndex]
-}
-
-// BAD: Binding can crash if array shrinks
-Binding(
-    get: { viewModel.items[index] },
-    set: { viewModel.items[index] = $0 }
-)
-
-// GOOD: Safe binding with bounds check
-Binding(
-    get: { index < viewModel.items.count ? viewModel.items[index] : defaultValue },
-    set: { if index < viewModel.items.count { viewModel.items[index] = $0 } }
-)
-```
-
----
-
-## 10. Dependencies & Integrations
-
-**Third-party libraries**
-- [ ] All dependencies up to date (or explicitly pinned for reason)
-- [ ] No deprecated dependencies
-- [ ] License compliance verified
-- [ ] No unused dependencies
-
-**API integration**
-- [ ] API endpoints correct
-- [ ] Request/response models match API spec
-- [ ] Error codes properly mapped
-- [ ] Rate limiting handled
-- [ ] Pagination implemented correctly
-
----
-
-## 11. Documentation
-
-**Code documentation**
-- [ ] Public APIs documented
-- [ ] Complex algorithms explained
-- [ ] Architecture decisions documented (if new patterns introduced)
-- [ ] README updated if user-facing changes
-- [ ] CHANGELOG updated
-
-**Comments quality**
-- [ ] No obvious comments (code is self-explanatory)
-- [ ] Why not what (explain reasoning, not mechanics)
-- [ ] Complex business logic explained
-- [ ] Workarounds documented with reasons
-
----
-
-## 12. Git Hygiene
-
-**Commit cleanliness**
-```bash
-# Review diff one more time
-git diff main...HEAD
-
-# Check commit history
-git log --oneline main..HEAD
-```
-
-**Final git checks**
-- [ ] No merge commits (rebase if needed)
-- [ ] Logical commit groupings
-- [ ] Descriptive commit messages
-- [ ] No "fix typo" or "oops" commits (squash if needed)
-- [ ] No unintended files committed
-- [ ] No large binary files added
-- [ ] .gitignore properly configured
-
----
-
-## 13. PR Size Validation
-
-**Line count check**
-```bash
-# Count total lines changed
-git diff --stat main...HEAD | tail -1
-```
-
-**Size requirements**
-- [ ] PR is < 1000 lines changed (HARD LIMIT)
-- [ ] If > 1000 lines, STOP and break into smaller PRs
-- [ ] Each PR is a logical, deployable unit
-- [ ] PR can be reviewed in < 30 minutes
-
-**If PR too large:**
-1. STOP immediately
-2. Analyze commits for logical break points
-3. Create feature branch for continuation
-4. Rebase/cherry-pick commits into smaller PRs
-5. Submit smaller PRs sequentially
-
----
-
-## 14. Final Manual Review
-
-**Self code review**
-- [ ] Read every line as if reviewing someone else's code
-- [ ] Question every decision
-- [ ] Look for simpler solutions
-- [ ] Check for over-engineering
-- [ ] Verify error messages are user-friendly
-- [ ] Ensure naming is clear and consistent
-
-**Pre-submit questions**
-- Would I approve this PR if someone else wrote it?
-- Is this the simplest solution that works?
-- Could a junior developer understand this in 6 months?
-- Does this follow team conventions?
-- Would I be proud to show this to a senior engineer?
-
----
-
-## Failure Protocol
-
-If ANY check fails:
-
-1. **DO NOT OPEN THE PR**
-2. Fix the issue immediately
-3. Re-run the ENTIRE checklist from the start
-4. Document what was fixed
-
-## Success Protocol
-
-Only after ALL checks pass:
-
-1. Generate PR description:
-   - What: Brief summary of changes
-   - Why: Motivation and context
-   - How: Implementation approach
-   - Testing: What was tested and how
-   - Screenshots: If UI changes
-   - Rollout: Any deployment considerations
-
-2. Add appropriate labels
-
-3. Assign reviewers
-
-4. Open PR with confidence
-
----
-
-## Automation Script
+## Phase 5: PR Size Validation
 
 ```bash
-#!/bin/bash
-# pre-pr-check.sh
-
-set -e  # Exit on any error
-
-echo "🔍 Starting comprehensive PR verification..."
-
-# 1. Branch check
-echo "✓ Verifying branch..."
-current_branch=$(git branch --show-current)
-if [ "$current_branch" = "main" ]; then
-    echo "❌ Cannot submit PR from main branch"
-    exit 1
-fi
-
-# 2. Clean build
-echo "✓ Running clean build..."
-xcodebuild clean -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15' -quiet
-xcodebuild build -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15' -quiet || {
-    echo "❌ Build failed"
-    exit 1
-}
-
-# 3. SwiftLint
-echo "✓ Running SwiftLint..."
-swiftlint lint --strict || {
-    echo "❌ SwiftLint violations found"
-    swiftlint lint
-    exit 1
-}
-
-# 4. Tests
-echo "✓ Running test suite..."
-xcodebuild test -scheme Nippardation -destination 'platform=iOS Simulator,name=iPhone 15' -quiet || {
-    echo "❌ Tests failed"
-    exit 1
-}
-
-# 5. Security check
-echo "✓ Checking for secrets..."
-if grep -rE "(API_KEY|api_key|secret|password.*=.*\"|token.*=.*\")" --include="*.swift" . ; then
-    echo "❌ Potential secrets found in code"
-    exit 1
-fi
-
-# 6. PR size check
-lines_changed=$(git diff --stat main...HEAD | tail -1 | awk '{print $4+$6}')
-if [ "$lines_changed" -gt 1000 ]; then
-    echo "❌ PR too large: $lines_changed lines changed (max 1000)"
-    echo "Break this into smaller PRs"
-    exit 1
-fi
-
-echo "✅ All checks passed! Ready to submit PR."
+git diff --stat develop...HEAD | tail -1
 ```
+
+- **Hard limit**: 1000 lines changed
+- If over, split before proceeding — do NOT open an oversized PR
 
 ---
 
-## Notes
+## Phase 6: Summary
 
-- This checklist is NON-NEGOTIABLE
-- Every step must pass
-- No shortcuts
-- No "I'll fix it later"
-- No "it's just a small change"
-- Quality over speed
-- The PR represents your craftsmanship
+Before committing/pushing, produce a summary of every fix applied:
 
-**Remember:** A PR that passes this checklist should sail through human review with minimal comments.
+```
+## Fixes Applied
+
+### HIGH
+- [file:line] Description of what was wrong and what was fixed
+
+### MEDIUM
+- [file:line] Description of what was wrong and what was fixed
+
+### LOW
+- [file:line] Description of what was wrong and what was fixed
+```
+
+This summary goes in the commit message body and can be referenced in PR comments.
+
+---
+
+## What This Catches That Checklists Don't
+
+- Decode methods that return `nil` prematurely because `APIEnvelope` with all-optional fields succeeds on any JSON
+- Views that flash "no data" messages before the first network call completes
+- `NavigationStack` missing from sheet-presented views (invisible toolbar/title)
+- `fullScreenCover` that opens blank when bound state is nil
+- `String.hashValue` used for colors (randomized per launch in Swift 4.2+)
+- Formatters allocated on every SwiftUI render pass
+- `@MainActor` properties read from `@Sendable` closures without capture
+- `withCheckedContinuation` that hangs if the wrapped task is cancelled
+- Struct `Equatable` that only checks `id` (SwiftUI won't re-render on property changes)
+- Duplicated private types across service files that diverge over time
+
+**These are the bugs that slip through checkbox reviews and get flagged by automated PR bots. This audit catches them first.**

--- a/Nippardation/Exercise/WorkoutSelectionView.swift
+++ b/Nippardation/Exercise/WorkoutSelectionView.swift
@@ -18,7 +18,12 @@ struct WorkoutSelectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {            
             List {
-                if let program = dashboardViewModel.activeProgram {
+                if dashboardViewModel.isLoading && dashboardViewModel.activeProgram == nil {
+                    Section("Active Program") {
+                        ProgressView()
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                } else if let program = dashboardViewModel.activeProgram {
                     Section("From Active Program: \(program.name)") {
                         ForEach(program.workouts.sorted(by: { $0.dayNumber < $1.dayNumber })) { workout in
                             if let template = dashboardViewModel.templateFor(workout: workout) {

--- a/Nippardation/Exercise/WorkoutSelectionView.swift
+++ b/Nippardation/Exercise/WorkoutSelectionView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct WorkoutSelectionView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
-    @ObservedObject var viewModel = HomeViewModel()
+    @StateObject private var dashboardViewModel = DashboardViewModel()
     @ObservedObject var workoutManager = WorkoutManager.shared
     
     var onWorkoutSelected: (TrackedWorkout) -> Void
@@ -18,10 +18,45 @@ struct WorkoutSelectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {            
             List {
-                Section("Select a workout to begin") {}
-                
-                ForEach(viewModel.workouts, id: \.self) { workout in
-                    Section {
+                if let program = dashboardViewModel.activeProgram {
+                    Section("From Active Program: \(program.name)") {
+                        ForEach(program.workouts.sorted(by: { $0.dayNumber < $1.dayNumber })) { workout in
+                            if let template = dashboardViewModel.templateFor(workout: workout) {
+                                Button {
+                                    startWorkout(template: workoutTemplate(from: template, fallbackName: workout.displayName))
+                                } label: {
+                                    HStack {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(workout.displayName)
+                                                .foregroundStyle(colorScheme == .dark ? Color.white : Color.appTheme)
+                                            Text("\(template.exerciseCount) exercises")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        Spacer()
+                                        Image(systemName: "play.circle.fill")
+                                            .resizable()
+                                            .frame(width: 32, height: 32)
+                                            .aspectRatio(contentMode: .fit)
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .disabled(template.exercises.isEmpty)
+                                .tint(Color.appTheme)
+                                .buttonStyle(.automatic)
+                            }
+                        }
+                    }
+                } else {
+                    Section("Active Program") {
+                        Text("No active program. Set one in the Programs tab to start workouts from your plan.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Section("Quick Start Workouts") {
+                    ForEach(fallbackWorkouts, id: \.self) { workout in
                         Button {
                             startWorkout(template: workout)
                         } label: {
@@ -45,20 +80,68 @@ struct WorkoutSelectionView: View {
         }
         .navigationTitle("Start Workout")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            dashboardViewModel.loadDashboard()
+        }
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button("Cancel") {
                     dismiss()
                 }
-                Color.appTheme
             }
         }
+    }
+
+    private var fallbackWorkouts: [Workout] {
+        [upperStrength, lowerStrength, pullDay, pushDay, legDay]
     }
     
     private func startWorkout(template: Workout) {
         let trackedWorkout = workoutManager.startWorkout(template: template)
         onWorkoutSelected(trackedWorkout)
         dismiss()
+    }
+
+    private func workoutTemplate(from template: Template, fallbackName: String) -> Workout {
+        let exercises = template.exercises
+            .sorted(by: { $0.orderIndex < $1.orderIndex })
+            .map { templateExercise in
+                let libraryItem = templateExercise.exerciseLibraryItem
+                let exerciseName = libraryItem?.name ?? "Exercise"
+                let muscles = libraryItem?.primaryMuscles ?? []
+
+                return Exercise(
+                    type: ExerciseType(name: exerciseName, muscleGroup: muscles),
+                    example: libraryItem?.videoUrl?.absoluteString ?? "",
+                    lastSetIntensityTechnique: templateExercise.notes ?? "Failure",
+                    warmUpSets: templateExercise.warmupSets ?? 0,
+                    workingSets: max(1, templateExercise.workingSets),
+                    reps: repsRange(from: templateExercise.targetReps),
+                    rest: restRange(from: templateExercise.restSeconds)
+                )
+            }
+
+        let workoutName = template.name.isEmpty ? fallbackName : template.name
+        return Workout(name: workoutName, exercises: exercises)
+    }
+
+    private func repsRange(from targetReps: String?) -> ClosedRange<Int> {
+        guard let targetReps, !targetReps.isEmpty else { return 8...12 }
+
+        let values = targetReps
+            .split(whereSeparator: { !$0.isNumber })
+            .compactMap { Int($0) }
+
+        guard let first = values.first else { return 8...12 }
+        let lower = max(1, first)
+        let upper = values.count > 1 ? max(lower, values[1]) : lower
+        return lower...upper
+    }
+
+    private func restRange(from restSeconds: Int?) -> ClosedRange<Int> {
+        let seconds = max(30, restSeconds ?? 90)
+        let minutes = max(1, Int(round(Double(seconds) / 60.0)))
+        return minutes...minutes
     }
 }
 

--- a/Nippardation/Home/HomeView.swift
+++ b/Nippardation/Home/HomeView.swift
@@ -109,8 +109,10 @@ struct HomeView: View {
             }
             .padding()
             .sheet(isPresented: $startNewWorkout) {
-                WorkoutSelectionView { workout in
-                    self.showActiveWorkout = true
+                NavigationStack {
+                    WorkoutSelectionView { workout in
+                        self.showActiveWorkout = true
+                    }
                 }
             }
             .fullScreenCover(isPresented: $showActiveWorkout) {
@@ -118,6 +120,9 @@ struct HomeView: View {
                     NavigationStack {
                         ActiveWorkoutView(workout: activeWorkout)
                     }
+                } else {
+                    // Fallback: dismiss if no active workout (race condition guard)
+                    Color.clear.onAppear { showActiveWorkout = false }
                 }
             }
         }

--- a/Nippardation/Home/HomeViewModel.swift
+++ b/Nippardation/Home/HomeViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Combine
 
 @MainActor
-class HomeViewModel: ObservableObject {
+final class HomeViewModel: ObservableObject {
     // Legacy workout templates (kept for backward compatibility)
     @Published var workouts: [Workout] = [
         upperStrength,

--- a/Nippardation/Models/API/ProgramDTO.swift
+++ b/Nippardation/Models/API/ProgramDTO.swift
@@ -25,7 +25,7 @@ struct ProgramDTO: Codable, Identifiable {
     let description: String?
     let daysPerWeek: Int
     let durationWeeks: Int?
-    let workouts: [ProgramWorkoutDTO]
+    let workouts: [ProgramWorkoutDTO]?
     let isActive: Bool?
     let currentDayIndex: Int?
     let timesCompleted: Int?

--- a/Nippardation/Models/API/TemplateDTO.swift
+++ b/Nippardation/Models/API/TemplateDTO.swift
@@ -23,7 +23,8 @@ struct TemplateDTO: Codable, Identifiable {
     let id: String
     let name: String
     let description: String?
-    let exercises: [TemplateExerciseDTO]
+    /// Present on full template payloads; omitted on summary payloads embedded in program responses
+    let exercises: [TemplateExerciseDTO]?
     let isPublic: Bool?
     let isAiGenerated: Bool?
     let createdAt: String?

--- a/Nippardation/Models/Domain/Program.swift
+++ b/Nippardation/Models/Domain/Program.swift
@@ -57,7 +57,7 @@ struct Program: Identifiable, Hashable {
 
     /// Human-readable duration string
     var durationString: String {
-        guard let weeks = durationWeeks, weeks > 0 else { return "Ongoing" }
+        guard let weeks = durationWeeks, weeks > 0 else { return "\u{221E}" }
         return weeks == 1 ? "1 week" : "\(weeks) weeks"
     }
 

--- a/Nippardation/Models/Domain/Program.swift
+++ b/Nippardation/Models/Domain/Program.swift
@@ -49,7 +49,7 @@ struct Program: Identifiable, Hashable {
 
     /// Progress percentage (0-1) based on duration
     var progress: Double {
-        guard let weeks = durationWeeks, weeks > 0, daysPerWeek > 0 else { return 0 }
+        guard let weeks = durationWeeks, weeks > 0, daysPerWeek > 0, !workouts.isEmpty else { return 0 }
         let completedDays = timesCompleted * workouts.count + currentDayIndex
         let totalDays = weeks * daysPerWeek
         return min(1.0, Double(completedDays) / Double(totalDays))

--- a/Nippardation/Models/Mappers/ProgramMapper.swift
+++ b/Nippardation/Models/Mappers/ProgramMapper.swift
@@ -21,7 +21,7 @@ enum ProgramMapper {
             description: dto.description,
             daysPerWeek: dto.daysPerWeek,
             durationWeeks: dto.durationWeeks,
-            workouts: dto.workouts.map { ProgramWorkoutMapper.toDomain($0) },
+            workouts: (dto.workouts ?? []).map { ProgramWorkoutMapper.toDomain($0) },
             isActive: dto.isActive ?? false,
             currentDayIndex: dto.currentDayIndex ?? 0,
             timesCompleted: dto.timesCompleted ?? 0,

--- a/Nippardation/Models/Mappers/TemplateMapper.swift
+++ b/Nippardation/Models/Mappers/TemplateMapper.swift
@@ -19,7 +19,7 @@ enum TemplateMapper {
             serverId: dto.id,
             name: dto.name,
             description: dto.description,
-            exercises: dto.exercises.map { TemplateExerciseMapper.toDomain($0) },
+            exercises: (dto.exercises ?? []).map { TemplateExerciseMapper.toDomain($0) },
             isPublic: dto.isPublic ?? false,
             isAiGenerated: dto.isAiGenerated ?? false,
             createdAt: parseDate(dto.createdAt) ?? Date(),

--- a/Nippardation/Services/API/BaseAPIService.swift
+++ b/Nippardation/Services/API/BaseAPIService.swift
@@ -110,4 +110,45 @@ class BaseAPIService: @unchecked Sendable {
             throw RepositoryError.unknown(nil)
         }
     }
+
+    // MARK: - Shared Decoding Helpers
+
+    func decodeFailure(_ error: Error, data: Data) -> RepositoryError {
+        #if DEBUG
+        print("Decoding error: \(error)")
+        if let json = String(data: data, encoding: .utf8) {
+            print("Response: \(json)")
+        }
+        #endif
+        return .unknown(error)
+    }
+}
+
+// MARK: - Shared API Response Models
+
+struct APIEnvelope<T: Decodable>: Decodable {
+    let success: Bool?
+    let data: T?
+    let correlationId: String?
+}
+
+struct CursorPaginationPayload: Decodable {
+    let nextCursor: String?
+    let hasMore: Bool?
+    let page: Int?
+    let totalPages: Int?
+
+    var paginationInfo: PaginationInfo {
+        if let hasMore {
+            return PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
+        }
+
+        if let page, let totalPages {
+            let hasMoreFromPage = page < totalPages
+            let nextCursorFromPage = hasMoreFromPage ? String(page + 1) : nil
+            return PaginationInfo(nextCursor: nextCursor ?? nextCursorFromPage, hasMore: hasMoreFromPage)
+        }
+
+        return PaginationInfo(nextCursor: nextCursor, hasMore: nextCursor != nil)
+    }
 }

--- a/Nippardation/Services/API/ProgramAPIService.swift
+++ b/Nippardation/Services/API/ProgramAPIService.swift
@@ -38,13 +38,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "GET"
         try await addAuthHeader(to: &request)
 
-        let response: ProgramListResponse = try await performRequest(request)
-
-        let hasMore = response.pagination.page < response.pagination.totalPages
-        let nextCursor = hasMore ? String(response.pagination.page + 1) : nil
-        let paginationInfo = PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
-
-        return (response.programs, paginationInfo)
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramList(from: data)
     }
 
     func fetchProgram(id: String) async throws -> ProgramDTO {
@@ -56,8 +52,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "GET"
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func fetchActiveProgram() async throws -> ActiveProgramDTO? {
@@ -69,7 +66,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         try await addAuthHeader(to: &request)
 
         do {
-            return try await performRequest(request)
+            let (data, response) = try await performRequestWithoutDecoding(request)
+            try validateResponse(response, data: data)
+            return try decodeActiveProgram(from: data)
         } catch RepositoryError.notFound {
             // No active program is a valid state
             return nil
@@ -84,8 +83,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpBody = try encoder.encode(createRequest)
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func updateProgram(id: String, _ updateRequest: UpdateProgramRequest) async throws -> ProgramDTO {
@@ -98,8 +98,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpBody = try encoder.encode(updateRequest)
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func updateProgramWorkouts(
@@ -120,8 +121,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpBody = try encoder.encode(WorkoutsWrapper(workouts: workouts))
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func deleteProgram(id: String) async throws {
@@ -149,8 +151,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "POST"
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func deactivateProgram(id: String) async throws -> ProgramDTO {
@@ -163,8 +166,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "POST"
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func advanceProgram(id: String) async throws -> ProgramDTO {
@@ -177,8 +181,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "POST"
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
     func resetProgram(id: String) async throws -> ProgramDTO {
@@ -191,8 +196,121 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "POST"
         try await addAuthHeader(to: &request)
 
-        let response: ProgramDetailResponse = try await performRequest(request)
-        return response.program
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeProgramDetail(from: data)
     }
 
+    // MARK: - Response Decoding
+
+    private func decodeProgramList(from data: Data) throws -> (programs: [ProgramDTO], pagination: PaginationInfo) {
+        if let wrappedCursor = try? decoder.decode(APIEnvelope<ProgramListCursorPayload>.self, from: data),
+           let payload = wrappedCursor.data {
+            return (payload.programs, payload.pagination.paginationInfo)
+        }
+
+        if let wrappedLegacy = try? decoder.decode(APIEnvelope<ProgramListResponse>.self, from: data),
+           let payload = wrappedLegacy.data {
+            let hasMore = payload.pagination.page < payload.pagination.totalPages
+            let nextCursor = hasMore ? String(payload.pagination.page + 1) : nil
+            return (payload.programs, PaginationInfo(nextCursor: nextCursor, hasMore: hasMore))
+        }
+
+        do {
+            let response = try decoder.decode(ProgramListResponse.self, from: data)
+            let hasMore = response.pagination.page < response.pagination.totalPages
+            let nextCursor = hasMore ? String(response.pagination.page + 1) : nil
+            return (response.programs, PaginationInfo(nextCursor: nextCursor, hasMore: hasMore))
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+
+    private func decodeProgramDetail(from data: Data) throws -> ProgramDTO {
+        if let wrappedDetail = try? decoder.decode(APIEnvelope<ProgramDetailResponse>.self, from: data),
+           let payload = wrappedDetail.data {
+            return payload.program
+        }
+
+        if let wrappedProgram = try? decoder.decode(APIEnvelope<ProgramDTO>.self, from: data),
+           let payload = wrappedProgram.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(ProgramDetailResponse.self, from: data).program
+        } catch {
+            do {
+                return try decoder.decode(ProgramDTO.self, from: data)
+            } catch {
+                throw decodeFailure(error, data: data)
+            }
+        }
+    }
+
+    private func decodeActiveProgram(from data: Data) throws -> ActiveProgramDTO? {
+        if let wrappedActive = try? decoder.decode(APIEnvelope<ActiveProgramDTO>.self, from: data) {
+            return wrappedActive.data
+        }
+
+        if let wrappedProgram = try? decoder.decode(APIEnvelope<ProgramDTO>.self, from: data),
+           let program = wrappedProgram.data {
+            return ActiveProgramDTO(program: program, nextWorkout: nil, isCompleted: false)
+        }
+
+        do {
+            return try decoder.decode(ActiveProgramDTO.self, from: data)
+        } catch {
+            do {
+                let program = try decoder.decode(ProgramDTO.self, from: data)
+                return ActiveProgramDTO(program: program, nextWorkout: nil, isCompleted: false)
+            } catch {
+                throw decodeFailure(error, data: data)
+            }
+        }
+    }
+
+    private func decodeFailure(_ error: Error, data: Data) -> RepositoryError {
+        #if DEBUG
+        print("Decoding error: \(error)")
+        if let json = String(data: data, encoding: .utf8) {
+            print("Response: \(json)")
+        }
+        #endif
+        return .unknown(error)
+    }
+}
+
+// MARK: - Private Response Models
+
+private struct APIEnvelope<T: Decodable>: Decodable {
+    let success: Bool?
+    let data: T?
+    let correlationId: String?
+}
+
+private struct CursorPaginationPayload: Decodable {
+    let nextCursor: String?
+    let hasMore: Bool?
+    let page: Int?
+    let totalPages: Int?
+
+    var paginationInfo: PaginationInfo {
+        if let hasMore {
+            return PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
+        }
+
+        if let page, let totalPages {
+            let hasMoreFromPage = page < totalPages
+            let nextCursorFromPage = hasMoreFromPage ? String(page + 1) : nil
+            return PaginationInfo(nextCursor: nextCursor ?? nextCursorFromPage, hasMore: hasMoreFromPage)
+        }
+
+        return PaginationInfo(nextCursor: nextCursor, hasMore: nextCursor != nil)
+    }
+}
+
+private struct ProgramListCursorPayload: Decodable {
+    let programs: [ProgramDTO]
+    let pagination: CursorPaginationPayload
 }

--- a/Nippardation/Services/API/ProgramAPIService.swift
+++ b/Nippardation/Services/API/ProgramAPIService.swift
@@ -24,11 +24,11 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
             resolvingAgainstBaseURL: false
         )!
 
-        let page = cursor.flatMap { Int($0) } ?? 1
-        components.queryItems = [
-            URLQueryItem(name: "page", value: String(page)),
-            URLQueryItem(name: "per_page", value: String(limit))
-        ]
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor = cursor {
+            queryItems.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = queryItems
 
         guard let url = components.url else {
             throw RepositoryError.unknown(nil)

--- a/Nippardation/Services/API/ProgramAPIService.swift
+++ b/Nippardation/Services/API/ProgramAPIService.swift
@@ -19,10 +19,12 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         cursor: String?,
         limit: Int
     ) async throws -> (programs: [ProgramDTO], pagination: PaginationInfo) {
-        var components = URLComponents(
+        guard var components = URLComponents(
             url: AppConfiguration.shared.baseURL.appendingPathComponent("api/programs"),
             resolvingAgainstBaseURL: false
-        )!
+        ) else {
+            throw RepositoryError.unknown(nil)
+        }
 
         var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
         if let cursor = cursor {
@@ -249,8 +251,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
     }
 
     private func decodeActiveProgram(from data: Data) throws -> ActiveProgramDTO? {
-        if let wrappedActive = try? decoder.decode(APIEnvelope<ActiveProgramDTO>.self, from: data) {
-            return wrappedActive.data
+        if let wrappedActive = try? decoder.decode(APIEnvelope<ActiveProgramDTO>.self, from: data),
+           let payload = wrappedActive.data {
+            return payload
         }
 
         if let wrappedProgram = try? decoder.decode(APIEnvelope<ProgramDTO>.self, from: data),
@@ -270,45 +273,9 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         }
     }
 
-    private func decodeFailure(_ error: Error, data: Data) -> RepositoryError {
-        #if DEBUG
-        print("Decoding error: \(error)")
-        if let json = String(data: data, encoding: .utf8) {
-            print("Response: \(json)")
-        }
-        #endif
-        return .unknown(error)
-    }
 }
 
 // MARK: - Private Response Models
-
-private struct APIEnvelope<T: Decodable>: Decodable {
-    let success: Bool?
-    let data: T?
-    let correlationId: String?
-}
-
-private struct CursorPaginationPayload: Decodable {
-    let nextCursor: String?
-    let hasMore: Bool?
-    let page: Int?
-    let totalPages: Int?
-
-    var paginationInfo: PaginationInfo {
-        if let hasMore {
-            return PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
-        }
-
-        if let page, let totalPages {
-            let hasMoreFromPage = page < totalPages
-            let nextCursorFromPage = hasMoreFromPage ? String(page + 1) : nil
-            return PaginationInfo(nextCursor: nextCursor ?? nextCursorFromPage, hasMore: hasMoreFromPage)
-        }
-
-        return PaginationInfo(nextCursor: nextCursor, hasMore: nextCursor != nil)
-    }
-}
 
 private struct ProgramListCursorPayload: Decodable {
     let programs: [ProgramDTO]

--- a/Nippardation/Services/API/TemplateAPIService.swift
+++ b/Nippardation/Services/API/TemplateAPIService.swift
@@ -38,13 +38,9 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         request.httpMethod = "GET"
         try await addAuthHeader(to: &request)
 
-        let response: TemplateListResponse = try await performRequest(request)
-
-        let hasMore = response.pagination.page < response.pagination.totalPages
-        let nextCursor = hasMore ? String(response.pagination.page + 1) : nil
-        let paginationInfo = PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
-
-        return (response.templates, paginationInfo)
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeTemplateList(from: data)
     }
 
     func fetchTemplate(id: String) async throws -> TemplateDTO {
@@ -56,8 +52,9 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         request.httpMethod = "GET"
         try await addAuthHeader(to: &request)
 
-        let response: TemplateDetailResponse = try await performRequest(request)
-        return response.template
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeTemplateDetail(from: data)
     }
 
     func createTemplate(_ createRequest: CreateTemplateRequest) async throws -> TemplateDTO {
@@ -68,8 +65,9 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         request.httpBody = try encoder.encode(createRequest)
         try await addAuthHeader(to: &request)
 
-        let response: TemplateDetailResponse = try await performRequest(request)
-        return response.template
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeTemplateDetail(from: data)
     }
 
     func updateTemplate(id: String, _ updateRequest: UpdateTemplateRequest) async throws -> TemplateDTO {
@@ -82,8 +80,9 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         request.httpBody = try encoder.encode(updateRequest)
         try await addAuthHeader(to: &request)
 
-        let response: TemplateDetailResponse = try await performRequest(request)
-        return response.template
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeTemplateDetail(from: data)
     }
 
     func updateTemplateExercises(
@@ -104,8 +103,9 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         request.httpBody = try encoder.encode(ExercisesWrapper(exercises: exercises))
         try await addAuthHeader(to: &request)
 
-        let response: TemplateDetailResponse = try await performRequest(request)
-        return response.template
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeTemplateDetail(from: data)
     }
 
     func cloneTemplate(id: String, newName: String?) async throws -> TemplateDTO {
@@ -124,8 +124,9 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         }
         try await addAuthHeader(to: &request)
 
-        let response: TemplateDetailResponse = try await performRequest(request)
-        return response.template
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeTemplateDetail(from: data)
     }
 
     func deleteTemplate(id: String) async throws {
@@ -148,4 +149,94 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         try validateResponse(response, data: data)
     }
 
+    // MARK: - Response Decoding
+
+    private func decodeTemplateList(from data: Data) throws -> (templates: [TemplateDTO], pagination: PaginationInfo) {
+        if let wrappedCursor = try? decoder.decode(TemplateAPIEnvelope<TemplateListCursorPayload>.self, from: data),
+           let payload = wrappedCursor.data {
+            return (payload.templates, payload.pagination.paginationInfo)
+        }
+
+        if let wrappedLegacy = try? decoder.decode(TemplateAPIEnvelope<TemplateListResponse>.self, from: data),
+           let payload = wrappedLegacy.data {
+            let hasMore = payload.pagination.page < payload.pagination.totalPages
+            let nextCursor = hasMore ? String(payload.pagination.page + 1) : nil
+            return (payload.templates, PaginationInfo(nextCursor: nextCursor, hasMore: hasMore))
+        }
+
+        do {
+            let response = try decoder.decode(TemplateListResponse.self, from: data)
+            let hasMore = response.pagination.page < response.pagination.totalPages
+            let nextCursor = hasMore ? String(response.pagination.page + 1) : nil
+            return (response.templates, PaginationInfo(nextCursor: nextCursor, hasMore: hasMore))
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+
+    private func decodeTemplateDetail(from data: Data) throws -> TemplateDTO {
+        if let wrappedDetail = try? decoder.decode(TemplateAPIEnvelope<TemplateDetailResponse>.self, from: data),
+           let payload = wrappedDetail.data {
+            return payload.template
+        }
+
+        if let wrappedTemplate = try? decoder.decode(TemplateAPIEnvelope<TemplateDTO>.self, from: data),
+           let payload = wrappedTemplate.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(TemplateDetailResponse.self, from: data).template
+        } catch {
+            do {
+                return try decoder.decode(TemplateDTO.self, from: data)
+            } catch {
+                throw decodeFailure(error, data: data)
+            }
+        }
+    }
+
+    private func decodeFailure(_ error: Error, data: Data) -> RepositoryError {
+        #if DEBUG
+        print("Decoding error: \(error)")
+        if let json = String(data: data, encoding: .utf8) {
+            print("Response: \(json)")
+        }
+        #endif
+        return .unknown(error)
+    }
+}
+
+// MARK: - Private Response Models
+
+private struct TemplateAPIEnvelope<T: Decodable>: Decodable {
+    let success: Bool?
+    let data: T?
+    let correlationId: String?
+}
+
+private struct TemplateCursorPaginationPayload: Decodable {
+    let nextCursor: String?
+    let hasMore: Bool?
+    let page: Int?
+    let totalPages: Int?
+
+    var paginationInfo: PaginationInfo {
+        if let hasMore {
+            return PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
+        }
+
+        if let page, let totalPages {
+            let hasMoreFromPage = page < totalPages
+            let nextCursorFromPage = hasMoreFromPage ? String(page + 1) : nil
+            return PaginationInfo(nextCursor: nextCursor ?? nextCursorFromPage, hasMore: hasMoreFromPage)
+        }
+
+        return PaginationInfo(nextCursor: nextCursor, hasMore: nextCursor != nil)
+    }
+}
+
+private struct TemplateListCursorPayload: Decodable {
+    let templates: [TemplateDTO]
+    let pagination: TemplateCursorPaginationPayload
 }

--- a/Nippardation/Services/API/TemplateAPIService.swift
+++ b/Nippardation/Services/API/TemplateAPIService.swift
@@ -19,10 +19,12 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         cursor: String?,
         limit: Int
     ) async throws -> (templates: [TemplateDTO], pagination: PaginationInfo) {
-        var components = URLComponents(
+        guard var components = URLComponents(
             url: AppConfiguration.shared.baseURL.appendingPathComponent("api/templates"),
             resolvingAgainstBaseURL: false
-        )!
+        ) else {
+            throw RepositoryError.unknown(nil)
+        }
 
         var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
         if let cursor = cursor {
@@ -152,12 +154,12 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
     // MARK: - Response Decoding
 
     private func decodeTemplateList(from data: Data) throws -> (templates: [TemplateDTO], pagination: PaginationInfo) {
-        if let wrappedCursor = try? decoder.decode(TemplateAPIEnvelope<TemplateListCursorPayload>.self, from: data),
+        if let wrappedCursor = try? decoder.decode(APIEnvelope<TemplateListCursorPayload>.self, from: data),
            let payload = wrappedCursor.data {
             return (payload.templates, payload.pagination.paginationInfo)
         }
 
-        if let wrappedLegacy = try? decoder.decode(TemplateAPIEnvelope<TemplateListResponse>.self, from: data),
+        if let wrappedLegacy = try? decoder.decode(APIEnvelope<TemplateListResponse>.self, from: data),
            let payload = wrappedLegacy.data {
             let hasMore = payload.pagination.page < payload.pagination.totalPages
             let nextCursor = hasMore ? String(payload.pagination.page + 1) : nil
@@ -175,12 +177,12 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
     }
 
     private func decodeTemplateDetail(from data: Data) throws -> TemplateDTO {
-        if let wrappedDetail = try? decoder.decode(TemplateAPIEnvelope<TemplateDetailResponse>.self, from: data),
+        if let wrappedDetail = try? decoder.decode(APIEnvelope<TemplateDetailResponse>.self, from: data),
            let payload = wrappedDetail.data {
             return payload.template
         }
 
-        if let wrappedTemplate = try? decoder.decode(TemplateAPIEnvelope<TemplateDTO>.self, from: data),
+        if let wrappedTemplate = try? decoder.decode(APIEnvelope<TemplateDTO>.self, from: data),
            let payload = wrappedTemplate.data {
             return payload
         }
@@ -195,48 +197,11 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
             }
         }
     }
-
-    private func decodeFailure(_ error: Error, data: Data) -> RepositoryError {
-        #if DEBUG
-        print("Decoding error: \(error)")
-        if let json = String(data: data, encoding: .utf8) {
-            print("Response: \(json)")
-        }
-        #endif
-        return .unknown(error)
-    }
 }
 
 // MARK: - Private Response Models
 
-private struct TemplateAPIEnvelope<T: Decodable>: Decodable {
-    let success: Bool?
-    let data: T?
-    let correlationId: String?
-}
-
-private struct TemplateCursorPaginationPayload: Decodable {
-    let nextCursor: String?
-    let hasMore: Bool?
-    let page: Int?
-    let totalPages: Int?
-
-    var paginationInfo: PaginationInfo {
-        if let hasMore {
-            return PaginationInfo(nextCursor: nextCursor, hasMore: hasMore)
-        }
-
-        if let page, let totalPages {
-            let hasMoreFromPage = page < totalPages
-            let nextCursorFromPage = hasMoreFromPage ? String(page + 1) : nil
-            return PaginationInfo(nextCursor: nextCursor ?? nextCursorFromPage, hasMore: hasMoreFromPage)
-        }
-
-        return PaginationInfo(nextCursor: nextCursor, hasMore: nextCursor != nil)
-    }
-}
-
 private struct TemplateListCursorPayload: Decodable {
     let templates: [TemplateDTO]
-    let pagination: TemplateCursorPaginationPayload
+    let pagination: CursorPaginationPayload
 }

--- a/Nippardation/Services/API/TemplateAPIService.swift
+++ b/Nippardation/Services/API/TemplateAPIService.swift
@@ -24,11 +24,11 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
             resolvingAgainstBaseURL: false
         )!
 
-        let page = cursor.flatMap { Int($0) } ?? 1
-        components.queryItems = [
-            URLQueryItem(name: "page", value: String(page)),
-            URLQueryItem(name: "per_page", value: String(limit))
-        ]
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor = cursor {
+            queryItems.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = queryItems
 
         guard let url = components.url else {
             throw RepositoryError.unknown(nil)

--- a/Nippardation/Services/DependencyContainer.swift
+++ b/Nippardation/Services/DependencyContainer.swift
@@ -114,13 +114,44 @@ final class DependencyContainer: ObservableObject {
     /// Configures the container with production services
     /// Called during app initialization
     func configureForProduction() {
-        // Register real video cache service
-        self.videoCacheService = VideoCacheService()
+        let authProvider = DefaultAuthTokenProvider.shared
 
-        // Register real exercise API service and repository
-        let exerciseAPI = ExerciseAPIService()
+        // API services
+        let exerciseAPI = ExerciseAPIService(authProvider: authProvider)
+        let templateAPI = TemplateAPIService(authProvider: authProvider)
+        let programAPI = ProgramAPIService(authProvider: authProvider)
+        let syncAPI = SyncAPIService(authProvider: authProvider)
+        let userAPI = UserAPIService(authProvider: authProvider)
+
         self.exerciseAPIService = exerciseAPI
-        self.exerciseRepository = ExerciseRepository(apiService: exerciseAPI)
+        self.templateAPIService = templateAPI
+        self.programAPIService = programAPI
+        self.syncAPIService = syncAPI
+        self.userAPIService = userAPI
+
+        // Repositories
+        let workoutRepository = WorkoutRepository(coreDataManager: .shared)
+        let exerciseRepository = ExerciseRepository(apiService: exerciseAPI, coreDataManager: .shared)
+        let templateRepository = TemplateRepository(apiService: templateAPI, coreDataManager: .shared)
+        let programRepository = ProgramRepository(apiService: programAPI, coreDataManager: .shared)
+
+        self.workoutRepository = workoutRepository
+        self.exerciseRepository = exerciseRepository
+        self.templateRepository = templateRepository
+        self.programRepository = programRepository
+
+        // Services
+        self.syncService = SyncService(
+            apiService: syncAPI,
+            workoutRepository: workoutRepository,
+            templateRepository: templateRepository,
+            programRepository: programRepository,
+            coreDataManager: .shared
+        )
+        self.videoCacheService = VideoCacheService(
+            templateRepository: templateRepository,
+            programRepository: programRepository
+        )
     }
 
     /// Configures the container with mock services for testing/previews

--- a/Nippardation/Services/Mocks/MockProgramAPIService.swift
+++ b/Nippardation/Services/Mocks/MockProgramAPIService.swift
@@ -70,7 +70,12 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
             throw errorToThrow
         }
 
-        let startIndex = cursor != nil ? min(Int(cursor!) ?? 0, programDTOs.count) : 0
+        let startIndex: Int
+        if let cursor, let parsed = Int(cursor) {
+            startIndex = min(parsed, programDTOs.count)
+        } else {
+            startIndex = 0
+        }
         let endIndex = min(startIndex + limit, programDTOs.count)
         let page = startIndex < programDTOs.count ? Array(programDTOs[startIndex..<endIndex]) : []
         let hasMore = endIndex < programDTOs.count

--- a/Nippardation/Services/Mocks/MockProgramAPIService.swift
+++ b/Nippardation/Services/Mocks/MockProgramAPIService.swift
@@ -48,7 +48,7 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
         if let activeProgram = programDTOs.first(where: { $0.isActive == true }) {
             activeProgramDTO = ActiveProgramDTO(
                 program: activeProgram,
-                nextWorkout: activeProgram.workouts.first { $0.dayNumber == (activeProgram.currentDayIndex ?? 0) },
+                nextWorkout: activeProgram.workouts?.first { $0.dayNumber == (activeProgram.currentDayIndex ?? 0) },
                 isCompleted: false
             )
         }
@@ -305,7 +305,7 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
         // Update active program response
         activeProgramDTO = ActiveProgramDTO(
             program: activated,
-            nextWorkout: activated.workouts.first { $0.dayNumber == (activated.currentDayIndex ?? 0) },
+            nextWorkout: activated.workouts?.first { $0.dayNumber == (activated.currentDayIndex ?? 0) },
             isCompleted: false
         )
 
@@ -365,7 +365,7 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
         let existing = programDTOs[index]
         let currentDay = existing.currentDayIndex ?? 0
         // Use workouts.count (matching domain model) with guard against zero
-        let workoutCount = max(existing.workouts.count, 1)
+        let workoutCount = max(existing.workouts?.count ?? 0, 1)
         let nextDayIndex = (currentDay + 1) % workoutCount
         let cycleCompleted = nextDayIndex == 0
 
@@ -392,7 +392,7 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
         if activeProgramDTO?.program.id == id {
             activeProgramDTO = ActiveProgramDTO(
                 program: advanced,
-                nextWorkout: advanced.workouts.first { $0.dayNumber == nextDayIndex },
+                nextWorkout: advanced.workouts?.first { $0.dayNumber == nextDayIndex },
                 isCompleted: false
             )
         }
@@ -435,7 +435,7 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
         if activeProgramDTO?.program.id == id {
             activeProgramDTO = ActiveProgramDTO(
                 program: reset,
-                nextWorkout: reset.workouts.first { $0.dayNumber == 0 },
+                nextWorkout: reset.workouts?.first { $0.dayNumber == 0 },
                 isCompleted: false
             )
         }

--- a/Nippardation/ViewModels/Exercises/ExerciseBrowserViewModel.swift
+++ b/Nippardation/ViewModels/Exercises/ExerciseBrowserViewModel.swift
@@ -98,13 +98,14 @@ final class ExerciseBrowserViewModel: ObservableObject {
             isLoadingMore = true
         }
 
+        let capturedFilter = self.filter
         Task {
             await taskManager.run(id: "loadExercises") { [weak self] in
                 guard let self = self else { return }
 
                 do {
                     let result = try await self.exerciseRepository.fetchExercises(
-                        filter: self.filter.isEmpty ? nil : self.filter,
+                        filter: capturedFilter.isEmpty ? nil : capturedFilter,
                         page: pageToFetch,
                         forceRefresh: refresh
                     )

--- a/Nippardation/ViewModels/Programs/ProgramDetailViewModel.swift
+++ b/Nippardation/ViewModels/Programs/ProgramDetailViewModel.swift
@@ -15,7 +15,7 @@ final class ProgramDetailViewModel: ObservableObject {
 
     @Published var program: Program?
     @Published var templates: [Template] = []
-    @Published var isLoading = false
+    @Published var isLoading = true
     @Published var error: String?
 
     // MARK: - Dependencies
@@ -56,7 +56,7 @@ final class ProgramDetailViewModel: ObservableObject {
                 do {
                     let program = try await self.programRepository.fetchProgram(
                         serverId: serverId,
-                        forceRefresh: false
+                        forceRefresh: true
                     )
 
                     // Load templates for each workout

--- a/Nippardation/ViewModels/Programs/ProgramListViewModel.swift
+++ b/Nippardation/ViewModels/Programs/ProgramListViewModel.swift
@@ -156,7 +156,7 @@ final class ProgramListViewModel: ObservableObject {
                     await MainActor.run {
                         // Update all programs to reflect new active state
                         self.programs = self.programs.map { p in
-                            if p.id == updated.id {
+                            if p.serverId == updated.serverId {
                                 return updated
                             } else if p.isActive {
                                 // Deactivate previously active program

--- a/Nippardation/Views/Dashboard/DashboardView.swift
+++ b/Nippardation/Views/Dashboard/DashboardView.swift
@@ -13,10 +13,10 @@ struct DashboardView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
+            VStack(spacing: AppSpacing.lg) {
                 if viewModel.isLoading && viewModel.activeProgram == nil {
                     ProgressView()
-                        .padding(.top, 50)
+                        .padding(.top, AppSpacing.xxl)
                 } else if let program = viewModel.activeProgram {
                     // Active program content
                     activeProgramContent(program)
@@ -50,7 +50,7 @@ struct DashboardView: View {
 
     @ViewBuilder
     private func activeProgramContent(_ program: Program) -> some View {
-        VStack(spacing: 20) {
+        VStack(spacing: AppSpacing.lg) {
             // Next workout card
             if let nextWorkout = viewModel.nextWorkout,
                let template = viewModel.nextTemplate {
@@ -75,7 +75,7 @@ struct DashboardView: View {
 
     @ViewBuilder
     private func programProgressSection(_ program: Program) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
             Text(program.name)
                 .font(.headline)
 
@@ -110,12 +110,12 @@ struct DashboardView: View {
         }
         .padding()
         .background(Color(.secondarySystemBackground))
-        .cornerRadius(16)
+        .cornerRadius(AppCornerRadius.large)
     }
 
     @ViewBuilder
     private func workoutCarouselSection(_ program: Program) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
             Text("Program Workouts")
                 .font(.headline)
 

--- a/Nippardation/Views/Exercises/ExerciseBrowserView.swift
+++ b/Nippardation/Views/Exercises/ExerciseBrowserView.swift
@@ -12,21 +12,28 @@ struct ExerciseBrowserView: View {
     @StateObject private var viewModel: ExerciseBrowserViewModel
 
     let onSelect: ((ExerciseLibraryItem) -> Void)?
+    let onConfirmSelection: (([ExerciseLibraryItem]) -> Void)?
 
     init(
         isPickerMode: Bool = false,
         maxSelections: Int? = nil,
-        onSelect: ((ExerciseLibraryItem) -> Void)? = nil
+        onSelect: ((ExerciseLibraryItem) -> Void)? = nil,
+        onConfirmSelection: (([ExerciseLibraryItem]) -> Void)? = nil
     ) {
         self._viewModel = StateObject(wrappedValue: ExerciseBrowserViewModel(
             isPickerMode: isPickerMode,
             maxSelections: maxSelections
         ))
         self.onSelect = onSelect
+        self.onConfirmSelection = onConfirmSelection
     }
 
     var body: some View {
-        ExerciseBrowserContent(viewModel: viewModel, onSelect: onSelect)
+        ExerciseBrowserContent(
+            viewModel: viewModel,
+            onSelect: onSelect,
+            onConfirmSelection: onConfirmSelection
+        )
     }
 }
 
@@ -37,13 +44,16 @@ struct ExerciseBrowserContent: View {
     @State private var showFilters = false
 
     let onSelect: ((ExerciseLibraryItem) -> Void)?
+    let onConfirmSelection: (([ExerciseLibraryItem]) -> Void)?
 
     init(
         viewModel: ExerciseBrowserViewModel,
-        onSelect: ((ExerciseLibraryItem) -> Void)? = nil
+        onSelect: ((ExerciseLibraryItem) -> Void)? = nil,
+        onConfirmSelection: (([ExerciseLibraryItem]) -> Void)? = nil
     ) {
         self.viewModel = viewModel
         self.onSelect = onSelect
+        self.onConfirmSelection = onConfirmSelection
     }
 
     /// Returns the currently selected exercises (for use with toolbar buttons)
@@ -89,10 +99,14 @@ struct ExerciseBrowserContent: View {
             }
 
             // Floating selection button
-            if viewModel.isPickerMode && !viewModel.selectedExercises.isEmpty {
+            if viewModel.isPickerMode,
+               !viewModel.selectedExercises.isEmpty,
+               let onConfirmSelection {
                 FloatingSelectionButton(
                     count: viewModel.selectedExercises.count,
-                    action: {}
+                    action: {
+                        onConfirmSelection(viewModel.selectedExercisesList)
+                    }
                 )
                 .padding(.bottom, AppSpacing.lg)
             }

--- a/Nippardation/Views/Programs/DayScheduleCard.swift
+++ b/Nippardation/Views/Programs/DayScheduleCard.swift
@@ -21,7 +21,7 @@ struct DayScheduleCard: View {
         HStack(spacing: AppSpacing.sm) {
             // Day circle
             VStack(spacing: AppSpacing.xxs) {
-                Text(dayNumber < dayNames.count ? dayNames[dayNumber] : "Day")
+                Text(dayNumber >= 0 && dayNumber < dayNames.count ? dayNames[dayNumber] : "Day")
                     .font(.caption2)
                     .foregroundColor(.secondary)
 

--- a/Nippardation/Views/Programs/ProgramDetailView.swift
+++ b/Nippardation/Views/Programs/ProgramDetailView.swift
@@ -28,6 +28,9 @@ struct ProgramDetailView: View {
                 programContent(program)
             } else if let error = viewModel.error {
                 errorView(error)
+            } else {
+                ProgressView("Loading...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .navigationTitle(viewModel.program?.name ?? "Program")

--- a/Nippardation/Views/Programs/ProgramDetailView.swift
+++ b/Nippardation/Views/Programs/ProgramDetailView.swift
@@ -42,7 +42,9 @@ struct ProgramDetailView: View {
                 }
             }
         }
-        .sheet(isPresented: $showEditSheet) {
+        .sheet(isPresented: $showEditSheet, onDismiss: {
+            viewModel.loadProgram()
+        }) {
             if let program = viewModel.program {
                 NavigationStack {
                     ProgramEditorView(existingProgram: program)

--- a/Nippardation/Views/Programs/ProgramListView.swift
+++ b/Nippardation/Views/Programs/ProgramListView.swift
@@ -31,6 +31,12 @@ struct ProgramListView: View {
                     ProgramWizardView()
                 }
             }
+            .onChange(of: showCreateProgram) { oldValue, newValue in
+                // Refresh list after create sheet closes so newly created programs appear immediately.
+                if oldValue && !newValue {
+                    viewModel.loadPrograms(refresh: true)
+                }
+            }
             .alert("Delete Program", isPresented: $showDeleteConfirmation) {
                 Button("Cancel", role: .cancel) {
                     programToDelete = nil
@@ -90,32 +96,52 @@ struct ProgramListView: View {
         ScrollView {
             LazyVStack(spacing: AppSpacing.md) {
                 ForEach(viewModel.programs) { program in
-                    NavigationLink(destination: ProgramDetailView(programServerId: program.serverId)) {
-                        ProgramLibraryCard(program: program)
-                    }
-                    .buttonStyle(.plain)
-                    .contextMenu {
-                        if !program.isActive {
+                    VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                        NavigationLink(destination: ProgramDetailView(programServerId: program.serverId)) {
+                            ProgramLibraryCard(program: program)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            if !program.isActive {
+                                Button {
+                                    viewModel.activateProgram(program)
+                                } label: {
+                                    Label("Activate", systemImage: "checkmark.circle")
+                                }
+                            }
+
                             Button {
-                                viewModel.activateProgram(program)
+                                viewModel.duplicateProgram(program)
                             } label: {
-                                Label("Activate", systemImage: "checkmark.circle")
+                                Label("Duplicate", systemImage: "doc.on.doc")
+                            }
+
+                            Divider()
+
+                            Button(role: .destructive) {
+                                programToDelete = program
+                                showDeleteConfirmation = true
+                            } label: {
+                                Label("Delete", systemImage: "trash")
                             }
                         }
 
-                        Button {
-                            viewModel.duplicateProgram(program)
-                        } label: {
-                            Label("Duplicate", systemImage: "doc.on.doc")
-                        }
-
-                        Divider()
-
-                        Button(role: .destructive) {
-                            programToDelete = program
-                            showDeleteConfirmation = true
-                        } label: {
-                            Label("Delete", systemImage: "trash")
+                        if program.isActive {
+                            Label("Current Active Program", systemImage: "checkmark.circle.fill")
+                                .font(.caption)
+                                .foregroundColor(.green)
+                                .padding(.horizontal, AppSpacing.xs)
+                        } else {
+                            Button {
+                                viewModel.activateProgram(program)
+                            } label: {
+                                Label("Set As Active", systemImage: "checkmark.circle")
+                                    .font(.caption)
+                                    .fontWeight(.semibold)
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
                         }
                     }
                 }

--- a/Nippardation/Views/Templates/TemplateEditorView.swift
+++ b/Nippardation/Views/Templates/TemplateEditorView.swift
@@ -101,7 +101,7 @@ struct TemplateEditorView: View {
             if viewModel.isSaving {
                 ProgressView("Saving...")
                     .padding()
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: AppCornerRadius.medium))
             }
         }
         .alert("Error", isPresented: .init(

--- a/Nippardation/Views/Templates/TemplateEditorView.swift
+++ b/Nippardation/Views/Templates/TemplateEditorView.swift
@@ -231,7 +231,12 @@ private struct ExercisePickerSheet: View {
 
     var body: some View {
         NavigationStack {
-            ExerciseBrowserContent(viewModel: browserViewModel)
+            ExerciseBrowserContent(
+                viewModel: browserViewModel,
+                onConfirmSelection: { selected in
+                    onConfirm(selected)
+                }
+            )
                 .navigationTitle("Select Exercises")
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {

--- a/Nippardation/Views/Templates/TemplateGridCard.swift
+++ b/Nippardation/Views/Templates/TemplateGridCard.swift
@@ -67,14 +67,18 @@ struct TemplateGridCard: View {
 
     private var colorForTemplate: Color {
         let colors: [Color] = [.blue, .green, .orange, .purple, .pink, .teal]
-        let hash = abs(template.name.hashValue)
-        return colors[hash % colors.count]
+        let hash = template.name.utf8.reduce(0) { $0 &+ Int($1) }
+        return colors[abs(hash) % colors.count]
     }
 
-    private var formattedDate: String {
+    private static let relativeDateFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: template.updatedAt, relativeTo: Date())
+        return formatter
+    }()
+
+    private var formattedDate: String {
+        Self.relativeDateFormatter.localizedString(for: template.updatedAt, relativeTo: Date())
     }
 }
 

--- a/Nippardation/Views/Templates/TemplateListView.swift
+++ b/Nippardation/Views/Templates/TemplateListView.swift
@@ -36,6 +36,12 @@ struct TemplateListView: View {
                     TemplateEditorView()
                 }
             }
+            .onChange(of: showCreateTemplate) { oldValue, newValue in
+                // Refresh list after create sheet closes so newly created templates appear immediately.
+                if oldValue && !newValue {
+                    viewModel.loadTemplates(refresh: true)
+                }
+            }
             .alert("Delete Template", isPresented: $showDeleteConfirmation) {
                 Button("Cancel", role: .cancel) {
                     templateToDelete = nil

--- a/NippardationTests/API/ProgramAPIServiceTests.swift
+++ b/NippardationTests/API/ProgramAPIServiceTests.swift
@@ -51,6 +51,28 @@ struct ProgramAPIServiceTests {
         }
     }
 
+    @Test func fetchProgramsDecodesWrappedResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = """
+            {"success":true,"data":{"programs":[],"pagination":{"nextCursor":null,"hasMore":false}},"correlationId":"req_test"}
+            """
+            return (response, body.data(using: .utf8))
+        }
+
+        let result = try await service.fetchPrograms(cursor: nil, limit: 10)
+        #expect(result.programs.isEmpty)
+        #expect(result.pagination.hasMore == false)
+        #expect(result.pagination.nextCursor == nil)
+    }
+
     // MARK: - fetchProgram Tests
 
     @Test func fetchProgramBuildsCorrectURL() async throws {

--- a/NippardationTests/API/ProgramAPIServiceTests.swift
+++ b/NippardationTests/API/ProgramAPIServiceTests.swift
@@ -35,11 +35,11 @@ struct ProgramAPIServiceTests {
             let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
             let queryItems = components?.queryItems ?? []
 
-            let pageItem = queryItems.first { $0.name == "page" }
-            let perPageItem = queryItems.first { $0.name == "per_page" }
+            let limitItem = queryItems.first { $0.name == "limit" }
+            let cursorItem = queryItems.first { $0.name == "cursor" }
 
-            #expect(pageItem?.value == "1")
-            #expect(perPageItem?.value == "10")
+            #expect(limitItem?.value == "10")
+            #expect(cursorItem == nil)
 
             return MockURLProtocol.errorResponse(for: request.url!, statusCode: 401)
         }
@@ -71,6 +71,30 @@ struct ProgramAPIServiceTests {
         #expect(result.programs.isEmpty)
         #expect(result.pagination.hasMore == false)
         #expect(result.pagination.nextCursor == nil)
+    }
+
+    @Test func fetchProgramsDecodesListWithWorkoutCount() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = """
+            {"success":true,"data":{"programs":[{"id":"prog_1","name":"PPL","daysPerWeek":6,"workoutCount":6,"isActive":true,"currentDayIndex":2,"timesCompleted":0,"createdAt":"2026-02-20T10:00:00.000Z","updatedAt":"2026-02-20T10:00:00.000Z"}],"pagination":{"nextCursor":null,"hasMore":false}},"correlationId":"req_test"}
+            """
+            return (response, body.data(using: .utf8))
+        }
+
+        let result = try await service.fetchPrograms(cursor: nil, limit: 10)
+        #expect(result.programs.count == 1)
+        #expect(result.programs[0].id == "prog_1")
+        #expect(result.programs[0].name == "PPL")
+        #expect(result.programs[0].workouts == nil)
+        #expect(result.pagination.hasMore == false)
     }
 
     // MARK: - fetchProgram Tests
@@ -176,9 +200,9 @@ struct ProgramAPIServiceTests {
 
         let dto = try await service.createProgram(createRequest)
         #expect(dto.id == "prog_123")
-        #expect(dto.workouts.count == 1)
-        #expect(dto.workouts.first?.template?.id == "tmpl_1")
-        #expect(dto.workouts.first?.template?.name == "Upper")
+        #expect(dto.workouts?.count == 1)
+        #expect(dto.workouts?.first?.template?.id == "tmpl_1")
+        #expect(dto.workouts?.first?.template?.name == "Upper")
     }
 
     // MARK: - updateProgram Tests

--- a/NippardationTests/API/ProgramAPIServiceTests.swift
+++ b/NippardationTests/API/ProgramAPIServiceTests.swift
@@ -149,6 +149,38 @@ struct ProgramAPIServiceTests {
         }
     }
 
+    @Test func createProgramDecodesWrappedResponseWithTemplateSummary() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = """
+            {"success":true,"data":{"program":{"id":"prog_123","name":"YOLO Swag","description":null,"daysPerWeek":5,"durationWeeks":null,"isActive":false,"currentDayIndex":0,"timesCompleted":0,"isPublic":false,"isAiGenerated":false,"workouts":[{"id":"w_1","dayNumber":0,"dayLabel":"Day 1","templateId":"tmpl_1","template":{"id":"tmpl_1","name":"Upper","description":null,"exerciseCount":8}}],"createdAt":"2026-02-23T17:33:13.533Z","updatedAt":"2026-02-23T17:33:13.533Z"}},"correlationId":"req_test"}
+            """
+            return (response, body.data(using: .utf8))
+        }
+
+        let createRequest = CreateProgramRequest(
+            name: "YOLO Swag",
+            description: nil,
+            daysPerWeek: 5,
+            durationWeeks: nil,
+            workouts: [],
+            isPublic: false
+        )
+
+        let dto = try await service.createProgram(createRequest)
+        #expect(dto.id == "prog_123")
+        #expect(dto.workouts.count == 1)
+        #expect(dto.workouts.first?.template?.id == "tmpl_1")
+        #expect(dto.workouts.first?.template?.name == "Upper")
+    }
+
     // MARK: - updateProgram Tests
 
     @Test func updateProgramBuildsCorrectRequest() async throws {

--- a/NippardationTests/API/TemplateAPIServiceTests.swift
+++ b/NippardationTests/API/TemplateAPIServiceTests.swift
@@ -51,6 +51,28 @@ struct TemplateAPIServiceTests {
         }
     }
 
+    @Test func fetchTemplatesDecodesWrappedResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = """
+            {"success":true,"data":{"templates":[],"pagination":{"nextCursor":null,"hasMore":false}},"correlationId":"req_test"}
+            """
+            return (response, body.data(using: .utf8))
+        }
+
+        let result = try await service.fetchTemplates(cursor: nil, limit: 10)
+        #expect(result.templates.isEmpty)
+        #expect(result.pagination.hasMore == false)
+        #expect(result.pagination.nextCursor == nil)
+    }
+
     @Test func fetchTemplatesWithCursorSetsCorrectPage() async throws {
         let (service, sessionID) = createService()
 

--- a/NippardationTests/API/TemplateAPIServiceTests.swift
+++ b/NippardationTests/API/TemplateAPIServiceTests.swift
@@ -35,11 +35,11 @@ struct TemplateAPIServiceTests {
             let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
             let queryItems = components?.queryItems ?? []
 
-            let pageItem = queryItems.first { $0.name == "page" }
-            let perPageItem = queryItems.first { $0.name == "per_page" }
+            let limitItem = queryItems.first { $0.name == "limit" }
+            let cursorItem = queryItems.first { $0.name == "cursor" }
 
-            #expect(pageItem?.value == "1")
-            #expect(perPageItem?.value == "10")
+            #expect(limitItem?.value == "10")
+            #expect(cursorItem == nil)
 
             return MockURLProtocol.errorResponse(for: request.url!, statusCode: 401)
         }
@@ -73,23 +73,46 @@ struct TemplateAPIServiceTests {
         #expect(result.pagination.nextCursor == nil)
     }
 
-    @Test func fetchTemplatesWithCursorSetsCorrectPage() async throws {
+    @Test func fetchTemplatesWithCursorSetsCorrectParam() async throws {
         let (service, sessionID) = createService()
 
         MockURLProtocol.setRequestHandler(for: sessionID) { request in
             let components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)
-            let pageItem = components?.queryItems?.first { $0.name == "page" }
+            let cursorItem = components?.queryItems?.first { $0.name == "cursor" }
 
-            #expect(pageItem?.value == "5")
+            #expect(cursorItem?.value == "abc123")
 
             return MockURLProtocol.errorResponse(for: request.url!, statusCode: 401)
         }
 
         do {
-            _ = try await service.fetchTemplates(cursor: "5", limit: 10)
+            _ = try await service.fetchTemplates(cursor: "abc123", limit: 10)
         } catch {
             // Expected
         }
+    }
+
+    @Test func fetchTemplatesDecodesListWithExerciseCount() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let body = """
+            {"success":true,"data":{"templates":[{"id":"tmpl_1","name":"Upper Body","exerciseCount":7,"isPublic":false,"createdAt":"2026-02-20T10:00:00.000Z","updatedAt":"2026-02-20T10:00:00.000Z"}],"pagination":{"nextCursor":null,"hasMore":false}},"correlationId":"req_test"}
+            """
+            return (response, body.data(using: .utf8))
+        }
+
+        let result = try await service.fetchTemplates(cursor: nil, limit: 10)
+        #expect(result.templates.count == 1)
+        #expect(result.templates[0].id == "tmpl_1")
+        #expect(result.templates[0].name == "Upper Body")
+        #expect(result.pagination.hasMore == false)
     }
 
     // MARK: - fetchTemplate Tests


### PR DESCRIPTION
## Summary

- Fix blank screen when navigating to program detail view by initializing `isLoading = true` and adding a fallback `ProgressView`
- Always fetch fresh program data from the detail endpoint to avoid stale cache with empty workouts
- Apply design system tokens (spacing, colors, components) to `ProgramDetailView`
- Replace "Ongoing" duration text with infinity symbol (`∞`) for indefinite programs

## Test plan

- [ ] Tap a program from the Home view active plan section — detail view shows loading then full content
- [ ] Tap a program from the Programs list — same behavior, no blank screen
- [ ] Verify workouts section populates with correct exercise counts
- [ ] Confirm indefinite programs show `∞` for duration instead of "Ongoing"
- [ ] Build succeeds and all unit tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes API request/query parameters and decoding paths for programs/templates (new envelope + cursor pagination + optional fields), which can affect data loading if server responses differ from expectations. UI updates add loading/race-condition guards but touch multiple navigation and state flows.
> 
> **Overview**
> **Fixes blank/broken program and workout flows** by tightening loading-state handling (e.g., `ProgramDetailViewModel.isLoading` defaults to true, `ProgramDetailView` adds a fallback `ProgressView`, and edit-sheet dismissal triggers a reload) and adding race-condition guards (e.g., `HomeView` dismisses `fullScreenCover` if `activeWorkout` is nil).
> 
> **Updates program/template networking to match newer API shapes**: `ProgramAPIService`/`TemplateAPIService` now use `limit` + `cursor` query params (instead of page/per_page), avoid `URLComponents(...)!`, and add multi-format decode fallbacks via shared `APIEnvelope`, `CursorPaginationPayload`, and `decodeFailure` helpers in `BaseAPIService`. DTOs (`ProgramDTO.workouts`, `TemplateDTO.exercises`) become optional with mappers defaulting to empty arrays; unit tests are updated/added to cover wrapped responses and summary payloads.
> 
> **UI polish + consistency**: design-token spacing/radius updates (e.g., `DashboardView`, `TemplateEditorView`), deterministic template card color hashing and static relative-date formatter (`TemplateGridCard`), safer indexing (`DayScheduleCard`), post-create refresh for template/program lists, and `WorkoutSelectionView` now supports starting workouts from the active program (with a quick-start fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7b76a7226a3719494d5b17c85bb273d76a391fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->