### PR TITLE
Add program & template sharing via deep links

### DIFF
--- a/Nippardation/Configuration/AppConfiguration.swift
+++ b/Nippardation/Configuration/AppConfiguration.swift
@@ -63,4 +63,8 @@ struct AppConfiguration {
             return "com.shillwil.Nippardation"
         }
     }
+
+    var shareURLScheme: String {
+        "nippardation"
+    }
 }

--- a/Nippardation/Docs/backend-share-api-spec.md
+++ b/Nippardation/Docs/backend-share-api-spec.md
@@ -1,0 +1,230 @@
+# Share API Specification
+
+## Overview
+
+The Share API enables users to share programs and templates with other users via shareable links. When a user shares an item, the backend creates a frozen snapshot of the item at that point in time. Subsequent edits to the original do not affect existing shares.
+
+Share links use the format: `nippardation://share/{token}`
+
+---
+
+## Endpoints
+
+### POST /api/shares
+
+Creates a new share for a program or template.
+
+**Authentication:** Required (Bearer token)
+
+**Request Body:**
+```json
+{
+  "type": "program" | "template",
+  "itemId": "string"
+}
+```
+
+| Field    | Type   | Required | Description                                    |
+|----------|--------|----------|------------------------------------------------|
+| `type`   | string | Yes      | The type of item being shared: `program` or `template` |
+| `itemId` | string | Yes      | The server ID of the program or template       |
+
+**Success Response (201 Created):**
+```json
+{
+  "success": true,
+  "data": {
+    "token": "abc123def456",
+    "shareUrl": "nippardation://share/abc123def456",
+    "expiresAt": null
+  }
+}
+```
+
+| Field       | Type        | Description                                     |
+|-------------|-------------|-------------------------------------------------|
+| `token`     | string      | Unique share token for the link                 |
+| `shareUrl`  | string      | Full share URL ready to distribute              |
+| `expiresAt` | string/null | ISO 8601 expiration date, or null if no expiry  |
+
+**Error Responses:**
+
+| Status | Condition                       | Body                                          |
+|--------|---------------------------------|-----------------------------------------------|
+| 401    | Missing or invalid auth token   | `{ "error": "Unauthorized" }`                 |
+| 404    | Item not found or not owned     | `{ "error": "Item not found" }`               |
+| 422    | Invalid type or missing itemId  | `{ "error": "Validation failed", "details": [...] }` |
+
+---
+
+### GET /api/shares/{token}
+
+Fetches the share details for previewing before import. Does NOT require authentication so recipients can preview before logging in.
+
+**Authentication:** Optional
+
+**Path Parameters:**
+
+| Parameter | Type   | Description       |
+|-----------|--------|-------------------|
+| `token`   | string | The share token   |
+
+**Success Response (200 OK):**
+
+For a **template** share:
+```json
+{
+  "success": true,
+  "data": {
+    "id": "share_001",
+    "token": "abc123def456",
+    "type": "template",
+    "sharedBy": {
+      "id": "user_001",
+      "displayName": "Jeff Nippard",
+      "avatarUrl": "https://example.com/avatar.jpg"
+    },
+    "sharedAt": "2026-03-08T12:00:00Z",
+    "template": {
+      "id": "tmpl_001",
+      "name": "Push Day",
+      "description": "Chest, shoulders, and triceps",
+      "exercises": [
+        {
+          "id": "te_001",
+          "exerciseId": "ex_001",
+          "exercise": {
+            "id": "ex_001",
+            "name": "Barbell Bench Press",
+            "primaryMuscles": ["chest"],
+            "equipment": "barbell"
+          },
+          "orderIndex": 0,
+          "warmupSets": 2,
+          "workingSets": 4,
+          "targetReps": "8-10",
+          "restSeconds": 180,
+          "notes": null
+        }
+      ],
+      "isPublic": false,
+      "isAiGenerated": false,
+      "createdAt": "2026-01-01T00:00:00Z",
+      "updatedAt": "2026-01-01T00:00:00Z"
+    },
+    "program": null
+  }
+}
+```
+
+For a **program** share:
+```json
+{
+  "success": true,
+  "data": {
+    "id": "share_002",
+    "token": "xyz789ghi012",
+    "type": "program",
+    "sharedBy": {
+      "id": "user_001",
+      "displayName": "Jeff Nippard",
+      "avatarUrl": "https://example.com/avatar.jpg"
+    },
+    "sharedAt": "2026-03-08T12:00:00Z",
+    "template": null,
+    "program": {
+      "id": "prog_001",
+      "name": "Upper/Lower Split",
+      "description": "4-day strength program",
+      "daysPerWeek": 4,
+      "durationWeeks": 8,
+      "workouts": [
+        {
+          "id": "pw_001",
+          "dayNumber": 1,
+          "dayLabel": "Upper A",
+          "templateId": "tmpl_001",
+          "template": {
+            "id": "tmpl_001",
+            "name": "Upper Body A",
+            "description": "Heavy compound upper",
+            "exercises": [...],
+            "isPublic": false,
+            "isAiGenerated": false,
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z"
+          }
+        }
+      ],
+      "isPublic": false,
+      "isAiGenerated": false,
+      "createdAt": "2026-01-01T00:00:00Z",
+      "updatedAt": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
+**Error Responses:**
+
+| Status | Condition                  | Body                                    |
+|--------|----------------------------|-----------------------------------------|
+| 404    | Token not found or expired | `{ "error": "Share not found" }`        |
+
+---
+
+## Database Schema
+
+### shares table
+
+| Column        | Type         | Constraints          | Description                                |
+|---------------|--------------|----------------------|--------------------------------------------|
+| `id`          | UUID/String  | PRIMARY KEY          | Unique share ID                            |
+| `token`       | VARCHAR(64)  | UNIQUE, NOT NULL, INDEX | URL-safe share token                    |
+| `type`        | ENUM         | NOT NULL             | `program` or `template`                    |
+| `item_id`     | VARCHAR(255) | NOT NULL             | Server ID of the shared item               |
+| `shared_by`   | VARCHAR(255) | NOT NULL, FK(users)  | User ID of the sharer                      |
+| `snapshot`    | JSONB/TEXT   | NOT NULL             | Frozen JSON snapshot of the item at share time |
+| `expires_at`  | TIMESTAMP    | NULL                 | Optional expiration (null = no expiry)     |
+| `created_at`  | TIMESTAMP    | NOT NULL, DEFAULT NOW | When the share was created                |
+
+### Indexes
+
+- `idx_shares_token` on `token` (unique) - Primary lookup
+- `idx_shares_shared_by` on `shared_by` - User's shares listing
+- `idx_shares_item` on `(type, item_id)` - Find shares for an item
+
+---
+
+## Token Generation
+
+- Tokens should be URL-safe alphanumeric strings
+- Recommended length: 12-16 characters
+- Must be globally unique
+- Example: `a3Bf9kLm2xQz`
+
+---
+
+## Snapshot Strategy
+
+When `POST /api/shares` is called:
+
+1. Fetch the full item (program or template) with all nested data
+2. For programs: include all workouts and their full template snapshots (with exercises)
+3. Serialize to JSON and store in the `snapshot` column
+4. The `GET /api/shares/{token}` endpoint returns the snapshot data directly
+
+This ensures:
+- Edits to the original don't affect existing shares
+- Deleted items don't break existing share links
+- The share is fully self-contained
+
+---
+
+## Notes
+
+- **No weight data**: Templates only store structure (exercises, sets, reps, rest). No user weight data is included.
+- **Exercise library references**: Exercise IDs reference the global exercise library. Recipients have access to the same library.
+- **No deduplication**: Each share creates a new token. Sharing the same item twice creates two independent shares.
+- **No expiration (MVP)**: Shares do not expire. Future enhancement can add optional TTL.
+- **Authentication for creation only**: Creating a share requires auth. Viewing a share does not, allowing link previews.

--- a/Nippardation/Info.plist
+++ b/Nippardation/Info.plist
@@ -2,5 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.shillwil.Nippardation</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>nippardation</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Nippardation/Models/API/ShareDTO.swift
+++ b/Nippardation/Models/API/ShareDTO.swift
@@ -1,0 +1,43 @@
+//
+//  ShareDTO.swift
+//  Nippardation
+//
+//  API Data Transfer Objects for sharing programs and templates
+//
+
+import Foundation
+
+// MARK: - Request DTOs
+
+/// Request body for POST /api/shares
+struct ShareCreateRequest: Codable {
+    let type: String
+    let itemId: String
+}
+
+// MARK: - Response DTOs
+
+/// Response from POST /api/shares
+struct ShareCreateResponse: Codable {
+    let token: String
+    let shareUrl: String
+    let expiresAt: String?
+}
+
+/// Response from GET /api/shares/{token}
+struct ShareDetailResponse: Codable {
+    let token: String
+    let type: String
+    let sharedBy: SharedByDTO
+    let sharedAt: String
+    let expiresAt: String?
+    let template: TemplateDTO?
+    let program: ProgramDTO?
+}
+
+/// Information about the user who shared the item
+struct SharedByDTO: Codable {
+    let handle: String
+    let displayName: String?
+    let avatarUrl: String?
+}

--- a/Nippardation/Models/Domain/SharedItem.swift
+++ b/Nippardation/Models/Domain/SharedItem.swift
@@ -1,0 +1,62 @@
+//
+//  SharedItem.swift
+//  Nippardation
+//
+//  Domain model for shared programs and templates
+//
+
+import Foundation
+
+/// The type of shared item
+enum ShareType: String {
+    case program
+    case template
+}
+
+/// Domain model representing a shared item received via a share link
+struct SharedItem {
+    let token: String
+    let type: ShareType
+    let sharedBy: SharedBy
+    let sharedAt: Date
+    let template: Template?
+    let program: Program?
+
+    struct SharedBy {
+        let handle: String
+        let displayName: String?
+        let avatarUrl: String?
+    }
+}
+
+// MARK: - Mapping from DTO
+
+extension SharedItem {
+    /// Creates a SharedItem from a ShareDetailResponse DTO
+    static func fromDTO(_ dto: ShareDetailResponse) -> SharedItem {
+        let type = ShareType(rawValue: dto.type) ?? .template
+
+        let sharedBy = SharedBy(
+            handle: dto.sharedBy.handle,
+            displayName: dto.sharedBy.displayName,
+            avatarUrl: dto.sharedBy.avatarUrl
+        )
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var sharedAt = formatter.date(from: dto.sharedAt)
+        if sharedAt == nil {
+            formatter.formatOptions = [.withInternetDateTime]
+            sharedAt = formatter.date(from: dto.sharedAt)
+        }
+
+        return SharedItem(
+            token: dto.token,
+            type: type,
+            sharedBy: sharedBy,
+            sharedAt: sharedAt ?? Date(),
+            template: dto.template.map { TemplateMapper.toDomain($0) },
+            program: dto.program.map { ProgramMapper.toDomain($0) }
+        )
+    }
+}

--- a/Nippardation/NippardationApp.swift
+++ b/Nippardation/NippardationApp.swift
@@ -13,6 +13,7 @@ struct NippardationApp: App {
     private let coreDataManager = CoreDataManager.shared
     @StateObject private var workoutManager = WorkoutManager.shared
     @StateObject private var authManager = AuthManager.shared
+    @StateObject private var deepLinkRouter = DeepLinkRouter.shared
     
     init() {
         StringArrayTransformer.register()
@@ -40,6 +41,10 @@ struct NippardationApp: App {
             if authManager.isAuthenticated {
                 MainTabView()
                     .environmentObject(authManager)
+                    .environmentObject(deepLinkRouter)
+                    .onOpenURL { url in
+                        deepLinkRouter.handleURL(url)
+                    }
                     .onChange(of: UIApplication.shared.applicationState) { oldState, newState in
                         if newState == .background {
                             coreDataManager.saveContext()

--- a/Nippardation/Services/API/ShareAPIService.swift
+++ b/Nippardation/Services/API/ShareAPIService.swift
@@ -1,0 +1,74 @@
+//
+//  ShareAPIService.swift
+//  Nippardation
+//
+//  API service for sharing programs and templates
+//
+
+import Foundation
+
+final class ShareAPIService: BaseAPIService, ShareAPIServiceProtocol, @unchecked Sendable {
+
+    override init(session: URLSession = .shared, authProvider: AuthTokenProviding = DefaultAuthTokenProvider.shared) {
+        super.init(session: session, authProvider: authProvider)
+    }
+
+    // MARK: - ShareAPIServiceProtocol
+
+    func createShare(type: String, itemId: String) async throws -> ShareCreateResponse {
+        let url = AppConfiguration.shared.baseURL.appendingPathComponent("api/shares")
+
+        let body = ShareCreateRequest(type: type, itemId: itemId)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = try encoder.encode(body)
+        try await addAuthHeader(to: &request)
+
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeCreateResponse(from: data)
+    }
+
+    func fetchShare(token: String) async throws -> ShareDetailResponse {
+        let url = AppConfiguration.shared.baseURL
+            .appendingPathComponent("api/shares")
+            .appendingPathComponent(token)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+        return try decodeDetailResponse(from: data)
+    }
+
+    // MARK: - Response Decoding
+
+    private func decodeCreateResponse(from data: Data) throws -> ShareCreateResponse {
+        if let wrapped = try? decoder.decode(APIEnvelope<ShareCreateResponse>.self, from: data),
+           let payload = wrapped.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(ShareCreateResponse.self, from: data)
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+
+    private func decodeDetailResponse(from data: Data) throws -> ShareDetailResponse {
+        if let wrapped = try? decoder.decode(APIEnvelope<ShareDetailResponse>.self, from: data),
+           let payload = wrapped.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(ShareDetailResponse.self, from: data)
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+}

--- a/Nippardation/Services/DeepLinkRouter.swift
+++ b/Nippardation/Services/DeepLinkRouter.swift
@@ -1,0 +1,68 @@
+//
+//  DeepLinkRouter.swift
+//  Nippardation
+//
+//  Parses nippardation:// URLs and manages pending share state
+//
+
+import Foundation
+import Combine
+
+private let deepLinkScheme = "nippardation"
+private let deepLinkShareHost = "share"
+
+/// Singleton that handles incoming deep links and exposes pending share tokens
+@MainActor
+final class DeepLinkRouter: ObservableObject {
+
+    static let shared = DeepLinkRouter()
+
+    /// The pending share token from an incoming URL, cleared after consumption
+    @Published var pendingShareToken: String?
+
+    private init() {}
+
+    /// Handles an incoming URL and extracts the share token if valid
+    /// - Parameter url: The URL received via onOpenURL
+    /// - Returns: true if the URL was handled
+    @discardableResult
+    func handleURL(_ url: URL) -> Bool {
+        guard let token = DeepLinkRouter.extractShareToken(from: url) else {
+            return false
+        }
+
+        pendingShareToken = token
+        return true
+    }
+
+    /// Clears the pending share token
+    func clearPendingToken() {
+        pendingShareToken = nil
+    }
+
+    /// Extracts a share token from a nippardation://share/TOKEN URL
+    /// - Parameter url: The URL to parse
+    /// - Returns: The token string, or nil if the URL is invalid
+    nonisolated static func extractShareToken(from url: URL) -> String? {
+        guard url.scheme == deepLinkScheme else { return nil }
+
+        // Handle both nippardation://share/TOKEN and nippardation:///share/TOKEN
+        let host = url.host()
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+
+        // Case 1: nippardation://share/TOKEN (host = "share", path = "/TOKEN")
+        if host == deepLinkShareHost, let token = pathComponents.first, !token.isEmpty {
+            return token
+        }
+
+        // Case 2: nippardation:///share/TOKEN (no host, path = "/share/TOKEN")
+        if host == nil || host?.isEmpty == true {
+            if pathComponents.count >= 2, pathComponents[0] == deepLinkShareHost {
+                let token = pathComponents[1]
+                return token.isEmpty ? nil : token
+            }
+        }
+
+        return nil
+    }
+}

--- a/Nippardation/Services/DependencyContainer.swift
+++ b/Nippardation/Services/DependencyContainer.swift
@@ -56,6 +56,9 @@ final class DependencyContainer: ObservableObject {
     /// User API service for API-level operations
     @Published private(set) var userAPIService: any UserAPIServiceProtocol
 
+    /// Share API service for sharing programs and templates
+    @Published private(set) var shareAPIService: any ShareAPIServiceProtocol
+
     // MARK: - Initialization
 
     private init() {
@@ -75,6 +78,7 @@ final class DependencyContainer: ObservableObject {
         self.programAPIService = MockProgramAPIService()
         self.syncAPIService = MockSyncAPIService()
         self.userAPIService = MockUserAPIService()
+        self.shareAPIService = MockShareAPIService()
     }
 
     // MARK: - Registration
@@ -122,12 +126,14 @@ final class DependencyContainer: ObservableObject {
         let programAPI = ProgramAPIService(authProvider: authProvider)
         let syncAPI = SyncAPIService(authProvider: authProvider)
         let userAPI = UserAPIService(authProvider: authProvider)
+        let shareAPI = ShareAPIService(authProvider: authProvider)
 
         self.exerciseAPIService = exerciseAPI
         self.templateAPIService = templateAPI
         self.programAPIService = programAPI
         self.syncAPIService = syncAPI
         self.userAPIService = userAPI
+        self.shareAPIService = shareAPI
 
         // Repositories
         let workoutRepository = WorkoutRepository(coreDataManager: .shared)
@@ -169,6 +175,7 @@ final class DependencyContainer: ObservableObject {
         self.programAPIService = MockProgramAPIService()
         self.syncAPIService = MockSyncAPIService()
         self.userAPIService = MockUserAPIService()
+        self.shareAPIService = MockShareAPIService()
     }
 
     // MARK: - API Service Setters (Used by Agent A)
@@ -201,6 +208,11 @@ final class DependencyContainer: ObservableObject {
     /// Called by Agent A after completion
     func setUserAPIService(_ service: any UserAPIServiceProtocol) {
         self.userAPIService = service
+    }
+
+    /// Replace share API service with real implementation
+    func setShareAPIService(_ service: any ShareAPIServiceProtocol) {
+        self.shareAPIService = service
     }
 
     /// Resets all services to their default state

--- a/Nippardation/Services/Mocks/MockShareAPIService.swift
+++ b/Nippardation/Services/Mocks/MockShareAPIService.swift
@@ -1,0 +1,211 @@
+//
+//  MockShareAPIService.swift
+//  Nippardation
+//
+//  Mock implementation of ShareAPIServiceProtocol for testing and development
+//
+
+import Foundation
+
+final class MockShareAPIService: ShareAPIServiceProtocol, @unchecked Sendable {
+
+    // MARK: - Test Configuration
+
+    var shouldThrowError = false
+    var errorToThrow: RepositoryError = .networkUnavailable
+    var fetchDelay: TimeInterval = 0.1
+
+    // MARK: - Call Tracking
+
+    private(set) var createShareCallCount = 0
+    private(set) var fetchShareCallCount = 0
+
+    private(set) var lastCreateType: String?
+    private(set) var lastCreateItemId: String?
+    private(set) var lastFetchToken: String?
+
+    // MARK: - Protocol Implementation
+
+    func createShare(type: String, itemId: String) async throws -> ShareCreateResponse {
+        createShareCallCount += 1
+        lastCreateType = type
+        lastCreateItemId = itemId
+
+        if fetchDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(fetchDelay * 1_000_000_000))
+        }
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+
+        let token = "mock_\(UUID().uuidString.prefix(8))"
+        return ShareCreateResponse(
+            token: token,
+            shareUrl: "nippardation://share/\(token)",
+            expiresAt: nil
+        )
+    }
+
+    func fetchShare(token: String) async throws -> ShareDetailResponse {
+        fetchShareCallCount += 1
+        lastFetchToken = token
+
+        if fetchDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(fetchDelay * 1_000_000_000))
+        }
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+
+        return Self.sampleShareDetail
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        createShareCallCount = 0
+        fetchShareCallCount = 0
+        lastCreateType = nil
+        lastCreateItemId = nil
+        lastFetchToken = nil
+        shouldThrowError = false
+    }
+}
+
+// MARK: - Sample Data
+
+extension MockShareAPIService {
+
+    static let sampleShareDetail = ShareDetailResponse(
+        token: "mock_abc123",
+        type: "program",
+        sharedBy: SharedByDTO(
+            handle: "jeffnippard",
+            displayName: "Jeff Nippard",
+            avatarUrl: nil
+        ),
+        sharedAt: "2026-03-08T12:00:00Z",
+        expiresAt: nil,
+        template: nil,
+        program: ProgramDTO(
+            id: "prog_001",
+            name: "Upper/Lower Split",
+            description: "4-day upper/lower strength program",
+            daysPerWeek: 4,
+            durationWeeks: 8,
+            workouts: [
+                ProgramWorkoutDTO(
+                    id: "pw_001",
+                    dayNumber: 1,
+                    dayLabel: "Upper A",
+                    templateId: "tmpl_001",
+                    template: TemplateDTO(
+                        id: "tmpl_001",
+                        name: "Upper Body A",
+                        description: "Heavy compound upper body",
+                        exercises: [
+                            TemplateExerciseDTO(
+                                id: "te_001",
+                                exerciseId: "ex_001",
+                                exercise: nil,
+                                orderIndex: 0,
+                                warmupSets: 2,
+                                workingSets: 4,
+                                targetReps: "6-8",
+                                restSeconds: 180,
+                                notes: nil
+                            )
+                        ],
+                        isPublic: false,
+                        isAiGenerated: false,
+                        createdAt: "2026-01-01T00:00:00Z",
+                        updatedAt: "2026-01-01T00:00:00Z"
+                    )
+                ),
+                ProgramWorkoutDTO(
+                    id: "pw_002",
+                    dayNumber: 2,
+                    dayLabel: "Lower A",
+                    templateId: "tmpl_002",
+                    template: TemplateDTO(
+                        id: "tmpl_002",
+                        name: "Lower Body A",
+                        description: "Heavy compound lower body",
+                        exercises: [
+                            TemplateExerciseDTO(
+                                id: "te_002",
+                                exerciseId: "ex_002",
+                                exercise: nil,
+                                orderIndex: 0,
+                                warmupSets: 3,
+                                workingSets: 4,
+                                targetReps: "5",
+                                restSeconds: 240,
+                                notes: nil
+                            )
+                        ],
+                        isPublic: false,
+                        isAiGenerated: false,
+                        createdAt: "2026-01-01T00:00:00Z",
+                        updatedAt: "2026-01-01T00:00:00Z"
+                    )
+                )
+            ],
+            isActive: false,
+            currentDayIndex: 0,
+            timesCompleted: 0,
+            isPublic: false,
+            isAiGenerated: false,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z"
+        )
+    )
+
+    static let sampleTemplateShareDetail = ShareDetailResponse(
+        token: "mock_def456",
+        type: "template",
+        sharedBy: SharedByDTO(
+            handle: "alexs",
+            displayName: "Alex S",
+            avatarUrl: nil
+        ),
+        sharedAt: "2026-03-08T14:00:00Z",
+        expiresAt: nil,
+        template: TemplateDTO(
+            id: "tmpl_003",
+            name: "Push Day",
+            description: "Chest, shoulders, and triceps",
+            exercises: [
+                TemplateExerciseDTO(
+                    id: "te_003",
+                    exerciseId: "ex_003",
+                    exercise: nil,
+                    orderIndex: 0,
+                    warmupSets: 2,
+                    workingSets: 4,
+                    targetReps: "8-10",
+                    restSeconds: 180,
+                    notes: nil
+                ),
+                TemplateExerciseDTO(
+                    id: "te_004",
+                    exerciseId: "ex_005",
+                    exercise: nil,
+                    orderIndex: 1,
+                    warmupSets: 1,
+                    workingSets: 3,
+                    targetReps: "12-15",
+                    restSeconds: 90,
+                    notes: nil
+                )
+            ],
+            isPublic: false,
+            isAiGenerated: false,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z"
+        ),
+        program: nil
+    )
+}

--- a/Nippardation/Services/Protocols/ShareAPIServiceProtocol.swift
+++ b/Nippardation/Services/Protocols/ShareAPIServiceProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  ShareAPIServiceProtocol.swift
+//  Nippardation
+//
+//  Protocol for share API operations
+//
+
+import Foundation
+
+/// Protocol for sharing programs and templates via shareable links
+protocol ShareAPIServiceProtocol: Sendable {
+
+    /// Create a new share for a program or template
+    /// - Parameters:
+    ///   - type: The item type ("program" or "template")
+    ///   - itemId: The server ID of the item to share
+    /// - Returns: Share creation response with token and URL
+    func createShare(type: String, itemId: String) async throws -> ShareCreateResponse
+
+    /// Fetch share details for previewing before import
+    /// - Parameter token: The share token from the URL
+    /// - Returns: Full share details including the shared item snapshot
+    func fetchShare(token: String) async throws -> ShareDetailResponse
+}

--- a/Nippardation/ViewModels/Sharing/ImportViewModel.swift
+++ b/Nippardation/ViewModels/Sharing/ImportViewModel.swift
@@ -1,0 +1,119 @@
+//
+//  ImportViewModel.swift
+//  Nippardation
+//
+//  ViewModel for importing shared programs and templates (inbound sharing)
+//
+
+import Foundation
+
+@MainActor
+final class ImportViewModel: ObservableObject {
+
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded
+        case importing
+        case imported
+        case error(String)
+
+        static func == (lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle), (.loading, .loading), (.loaded, .loaded),
+                 (.importing, .importing), (.imported, .imported):
+                return true
+            case (.error(let a), .error(let b)):
+                return a == b
+            default:
+                return false
+            }
+        }
+    }
+
+    @Published var state: State = .idle
+    @Published var sharedItem: SharedItem?
+
+    private let shareAPIService: any ShareAPIServiceProtocol
+    private let templateRepository: any TemplateRepositoryProtocol
+    private let programRepository: any ProgramRepositoryProtocol
+    private var token: String?
+
+    init(
+        shareAPIService: (any ShareAPIServiceProtocol)? = nil,
+        templateRepository: (any TemplateRepositoryProtocol)? = nil,
+        programRepository: (any ProgramRepositoryProtocol)? = nil
+    ) {
+        self.shareAPIService = shareAPIService ?? DependencyContainer.shared.shareAPIService
+        self.templateRepository = templateRepository ?? DependencyContainer.shared.templateRepository
+        self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+    }
+
+    /// Fetches the share preview from the backend
+    func fetchShare(token: String) {
+        self.token = token
+        state = .loading
+        sharedItem = nil
+
+        Task {
+            do {
+                let response = try await shareAPIService.fetchShare(token: token)
+                self.sharedItem = SharedItem.fromDTO(response)
+                self.state = .loaded
+            } catch let error as RepositoryError {
+                if case .notFound = error {
+                    self.state = .error("This share link is invalid or has expired.")
+                } else {
+                    self.state = .error(error.errorDescription ?? "Failed to load shared item")
+                }
+            } catch {
+                self.state = .error("Failed to load shared item")
+            }
+        }
+    }
+
+    /// Retries fetching the share preview
+    func retry() {
+        guard let token = token else { return }
+        fetchShare(token: token)
+    }
+
+    /// Imports the shared item into the user's library
+    func importItem() {
+        guard let item = sharedItem else { return }
+        state = .importing
+
+        Task {
+            do {
+                switch item.type {
+                case .template:
+                    guard let template = item.template else {
+                        self.state = .error("No template data found")
+                        return
+                    }
+                    _ = try await templateRepository.createTemplate(template)
+
+                case .program:
+                    guard let program = item.program else {
+                        self.state = .error("No program data found")
+                        return
+                    }
+                    // For programs, first import all templates, then create the program
+                    // The backend snapshot includes full template data in the program workouts
+                    for workout in program.workouts {
+                        if let template = workout.template {
+                            _ = try await templateRepository.createTemplate(template)
+                        }
+                    }
+                    _ = try await programRepository.createProgram(program)
+                }
+
+                self.state = .imported
+            } catch let error as RepositoryError {
+                self.state = .error(error.errorDescription ?? "Failed to import")
+            } catch {
+                self.state = .error("Failed to import")
+            }
+        }
+    }
+}

--- a/Nippardation/ViewModels/Sharing/ShareViewModel.swift
+++ b/Nippardation/ViewModels/Sharing/ShareViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  ShareViewModel.swift
+//  Nippardation
+//
+//  ViewModel for creating share links (outbound sharing)
+//
+
+import Foundation
+
+@MainActor
+final class ShareViewModel: ObservableObject {
+
+    @Published var isLoading = false
+    @Published var shareURL: URL?
+    @Published var error: String?
+
+    private let shareAPIService: any ShareAPIServiceProtocol
+
+    init(shareAPIService: (any ShareAPIServiceProtocol)? = nil) {
+        self.shareAPIService = shareAPIService ?? DependencyContainer.shared.shareAPIService
+    }
+
+    /// Creates a share link for a program or template
+    /// - Parameters:
+    ///   - type: "program" or "template"
+    ///   - itemId: The server ID of the item to share
+    func createShare(type: String, itemId: String) {
+        guard !isLoading else { return }
+        isLoading = true
+        error = nil
+        shareURL = nil
+
+        Task {
+            do {
+                let response = try await shareAPIService.createShare(type: type, itemId: itemId)
+                self.shareURL = URL(string: response.shareUrl)
+                self.isLoading = false
+            } catch let repoError as RepositoryError {
+                self.error = repoError.errorDescription ?? "Failed to create share link"
+                self.isLoading = false
+            } catch {
+                self.error = "Failed to create share link"
+                self.isLoading = false
+            }
+        }
+    }
+
+    func clearError() {
+        error = nil
+    }
+}

--- a/Nippardation/ViewModels/Templates/TemplateEditorViewModel.swift
+++ b/Nippardation/ViewModels/Templates/TemplateEditorViewModel.swift
@@ -49,6 +49,7 @@ final class TemplateEditorViewModel: ObservableObject {
 
     private var existingTemplate: Template?
     var isEditing: Bool { existingTemplate != nil }
+    var existingServerId: String? { existingTemplate?.serverId }
 
     // MARK: - Computed Properties
 

--- a/Nippardation/Views/Programs/ProgramDetailView.swift
+++ b/Nippardation/Views/Programs/ProgramDetailView.swift
@@ -13,6 +13,8 @@ struct ProgramDetailView: View {
     @StateObject private var viewModel: ProgramDetailViewModel
     @State private var showEditSheet = false
     @State private var showResetConfirmation = false
+    @State private var showShareSheet = false
+    @StateObject private var shareViewModel = ShareViewModel()
 
     init(programServerId: String) {
         self.programServerId = programServerId
@@ -37,8 +39,22 @@ struct ProgramDetailView: View {
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button("Edit") {
-                    showEditSheet = true
+                HStack(spacing: AppSpacing.sm) {
+                    Button {
+                        shareViewModel.createShare(type: "program", itemId: programServerId)
+                    } label: {
+                        if shareViewModel.isLoading {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                    .disabled(shareViewModel.isLoading)
+
+                    Button("Edit") {
+                        showEditSheet = true
+                    }
                 }
             }
         }
@@ -50,6 +66,24 @@ struct ProgramDetailView: View {
                     ProgramEditorView(existingProgram: program)
                 }
             }
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let url = shareViewModel.shareURL {
+                ShareActivityView(activityItems: [url])
+            }
+        }
+        .onChange(of: shareViewModel.shareURL) { _, url in
+            if url != nil {
+                showShareSheet = true
+            }
+        }
+        .alert("Sharing Error", isPresented: .init(
+            get: { shareViewModel.error != nil },
+            set: { if !$0 { shareViewModel.clearError() } }
+        )) {
+            Button("OK") { shareViewModel.clearError() }
+        } message: {
+            Text(shareViewModel.error ?? "")
         }
         .alert("Reset Progress", isPresented: $showResetConfirmation) {
             Button("Cancel", role: .cancel) {}

--- a/Nippardation/Views/Programs/ProgramListView.swift
+++ b/Nippardation/Views/Programs/ProgramListView.swift
@@ -13,6 +13,8 @@ struct ProgramListView: View {
     @State private var showCreateProgram = false
     @State private var programToDelete: Program?
     @State private var showDeleteConfirmation = false
+    @State private var showShareSheet = false
+    @StateObject private var shareViewModel = ShareViewModel()
 
     var body: some View {
         content
@@ -49,6 +51,24 @@ struct ProgramListView: View {
                 }
             } message: {
                 Text("Are you sure you want to delete this program? This cannot be undone.")
+            }
+            .sheet(isPresented: $showShareSheet) {
+                if let url = shareViewModel.shareURL {
+                    ShareActivityView(activityItems: [url])
+                }
+            }
+            .onChange(of: shareViewModel.shareURL) { _, url in
+                if url != nil {
+                    showShareSheet = true
+                }
+            }
+            .alert("Sharing Error", isPresented: .init(
+                get: { shareViewModel.error != nil },
+                set: { if !$0 { shareViewModel.clearError() } }
+            )) {
+                Button("OK") { shareViewModel.clearError() }
+            } message: {
+                Text(shareViewModel.error ?? "")
             }
             .refreshable {
                 await viewModel.refreshAsync()
@@ -114,6 +134,12 @@ struct ProgramListView: View {
                                 viewModel.duplicateProgram(program)
                             } label: {
                                 Label("Duplicate", systemImage: "doc.on.doc")
+                            }
+
+                            Button {
+                                shareViewModel.createShare(type: "program", itemId: program.serverId)
+                            } label: {
+                                Label("Share", systemImage: "square.and.arrow.up")
                             }
 
                             Divider()

--- a/Nippardation/Views/Root/MainTabView.swift
+++ b/Nippardation/Views/Root/MainTabView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct MainTabView: View {
     @EnvironmentObject private var authManager: AuthManager
+    @EnvironmentObject private var deepLinkRouter: DeepLinkRouter
     @State private var selectedTab: AppTab = .home
+    @State private var showSharePreview = false
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -55,6 +57,20 @@ struct MainTabView: View {
         }
         .tint(Color.appTheme)
         .environmentBanner()
+        .onChange(of: deepLinkRouter.pendingShareToken) { _, token in
+            if token != nil {
+                showSharePreview = true
+            }
+        }
+        .sheet(isPresented: $showSharePreview) {
+            deepLinkRouter.clearPendingToken()
+        } content: {
+            if let token = deepLinkRouter.pendingShareToken {
+                SharePreviewView(token: token) {
+                    showSharePreview = false
+                }
+            }
+        }
     }
 }
 

--- a/Nippardation/Views/Sharing/ShareActivityView.swift
+++ b/Nippardation/Views/Sharing/ShareActivityView.swift
@@ -1,0 +1,18 @@
+//
+//  ShareActivityView.swift
+//  Nippardation
+//
+//  UIActivityViewController wrapper for sharing URLs via the system share sheet
+//
+
+import SwiftUI
+
+struct ShareActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/Nippardation/Views/Sharing/SharePreviewView.swift
+++ b/Nippardation/Views/Sharing/SharePreviewView.swift
@@ -1,0 +1,292 @@
+//
+//  SharePreviewView.swift
+//  Nippardation
+//
+//  Preview screen shown when a user opens a share link
+//
+
+import SwiftUI
+
+struct SharePreviewView: View {
+
+    let token: String
+    let onDismiss: () -> Void
+
+    @StateObject private var viewModel = ImportViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch viewModel.state {
+                case .idle, .loading:
+                    loadingView
+                case .loaded:
+                    if let item = viewModel.sharedItem {
+                        previewContent(item)
+                    }
+                case .importing:
+                    importingView
+                case .imported:
+                    successView
+                case .error(let message):
+                    errorView(message)
+                }
+            }
+            .navigationTitle("Shared with You")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Close") {
+                        onDismiss()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            viewModel.fetchShare(token: token)
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        VStack(spacing: AppSpacing.md) {
+            ProgressView()
+                .controlSize(.large)
+            Text("Loading shared item...")
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Preview Content
+
+    @ViewBuilder
+    private func previewContent(_ item: SharedItem) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.lg) {
+                // Shared by header
+                sharedBySection(item)
+
+                // Item details
+                switch item.type {
+                case .template:
+                    if let template = item.template {
+                        templatePreview(template)
+                    }
+                case .program:
+                    if let program = item.program {
+                        programPreview(program)
+                    }
+                }
+
+                // Import button
+                Button {
+                    viewModel.importItem()
+                } label: {
+                    Label("Import to My Library", systemImage: "square.and.arrow.down")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+
+    private func sharedBySection(_ item: SharedItem) -> some View {
+        HStack(spacing: AppSpacing.sm) {
+            Image(systemName: "person.circle.fill")
+                .font(.title)
+                .foregroundColor(.secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Shared by \(item.sharedBy.displayName ?? item.sharedBy.handle)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Text(item.sharedAt, style: .date)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            PillBadge(
+                text: item.type == .program ? "Program" : "Template",
+                color: item.type == .program ? .blue : .appTheme
+            )
+        }
+        .padding(AppSpacing.md)
+        .cardStyle()
+    }
+
+    private func templatePreview(_ template: Template) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            Text(template.name)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            if let description = template.description {
+                Text(description)
+                    .foregroundColor(.secondary)
+            }
+
+            // Stats
+            HStack(spacing: AppSpacing.lg) {
+                statItem(value: "\(template.exerciseCount)", label: "Exercises")
+                statItem(value: "\(template.totalWorkingSets)", label: "Working Sets")
+                statItem(value: "\(template.estimatedDurationMinutes)m", label: "Est. Duration")
+            }
+            .padding(.vertical, AppSpacing.xs)
+
+            // Exercise list
+            if !template.exercises.isEmpty {
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("Exercises")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    ForEach(template.exercises.sorted(by: { $0.orderIndex < $1.orderIndex })) { exercise in
+                        exerciseRow(exercise)
+                    }
+                }
+            }
+        }
+    }
+
+    private func programPreview(_ program: Program) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            Text(program.name)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            if let description = program.description {
+                Text(description)
+                    .foregroundColor(.secondary)
+            }
+
+            // Stats
+            HStack(spacing: AppSpacing.lg) {
+                statItem(value: "\(program.daysPerWeek)", label: "Days/Week")
+                statItem(value: program.durationString, label: "Duration")
+                statItem(value: "\(program.workouts.count)", label: "Workouts")
+            }
+            .padding(.vertical, AppSpacing.xs)
+
+            // Workout list
+            if !program.workouts.isEmpty {
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("Workouts")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+
+                    ForEach(program.workouts.sorted(by: { $0.dayNumber < $1.dayNumber })) { workout in
+                        workoutRow(workout)
+                    }
+                }
+            }
+        }
+    }
+
+    private func exerciseRow(_ exercise: TemplateExercise) -> some View {
+        HStack {
+            Text(exercise.displayName)
+                .font(.subheadline)
+            Spacer()
+            Text(exercise.setSummary)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(AppSpacing.sm)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(AppCornerRadius.small)
+    }
+
+    private func workoutRow(_ workout: ProgramWorkout) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(workout.displayName)
+                    .font(.subheadline)
+                if let template = workout.template {
+                    Text("\(template.exerciseCount) exercises")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            Text("Day \(workout.dayNumber)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(AppSpacing.sm)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(AppCornerRadius.small)
+    }
+
+    private func statItem(value: String, label: String) -> some View {
+        VStack {
+            Text(value)
+                .font(.title3)
+                .fontWeight(.bold)
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    // MARK: - Importing
+
+    private var importingView: some View {
+        VStack(spacing: AppSpacing.md) {
+            ProgressView()
+                .controlSize(.large)
+            Text("Importing...")
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Success
+
+    private var successView: some View {
+        VStack(spacing: AppSpacing.md) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 60))
+                .foregroundColor(.green)
+
+            Text("Imported Successfully!")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text("The \(viewModel.sharedItem?.type == .program ? "program" : "template") has been added to your library.")
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button("Done") {
+                onDismiss()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.top, AppSpacing.md)
+        }
+        .padding(AppSpacing.lg)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Error
+
+    private func errorView(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label("Unable to Load", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Retry") {
+                viewModel.retry()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}

--- a/Nippardation/Views/Templates/TemplateEditorView.swift
+++ b/Nippardation/Views/Templates/TemplateEditorView.swift
@@ -14,6 +14,8 @@ struct TemplateEditorView: View {
 
     @State private var showExercisePicker = false
     @State private var editingExercise: ExerciseEditContext?
+    @State private var showShareSheet = false
+    @StateObject private var shareViewModel = ShareViewModel()
 
     /// Optional callback fired with the newly saved template
     private var onSave: ((Template) -> Void)?
@@ -59,15 +61,51 @@ struct TemplateEditorView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button("Save") {
-                    viewModel.save()
+                HStack(spacing: AppSpacing.sm) {
+                    if viewModel.isEditing {
+                        Button {
+                            if let serverId = viewModel.existingServerId {
+                                shareViewModel.createShare(type: "template", itemId: serverId)
+                            }
+                        } label: {
+                            if shareViewModel.isLoading {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "square.and.arrow.up")
+                            }
+                        }
+                        .disabled(shareViewModel.isLoading)
+                    }
+
+                    Button("Save") {
+                        viewModel.save()
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(!viewModel.isValid || viewModel.isSaving)
                 }
-                .fontWeight(.semibold)
-                .disabled(!viewModel.isValid || viewModel.isSaving)
             }
         }
         .sheet(isPresented: $showExercisePicker) {
             exercisePickerSheet
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let url = shareViewModel.shareURL {
+                ShareActivityView(activityItems: [url])
+            }
+        }
+        .onChange(of: shareViewModel.shareURL) { _, url in
+            if url != nil {
+                showShareSheet = true
+            }
+        }
+        .alert("Sharing Error", isPresented: .init(
+            get: { shareViewModel.error != nil },
+            set: { if !$0 { shareViewModel.clearError() } }
+        )) {
+            Button("OK") { shareViewModel.clearError() }
+        } message: {
+            Text(shareViewModel.error ?? "")
         }
         .sheet(item: $editingExercise) { context in
             ExerciseConfigSheet(

--- a/Nippardation/Views/Templates/TemplateListView.swift
+++ b/Nippardation/Views/Templates/TemplateListView.swift
@@ -13,6 +13,8 @@ struct TemplateListView: View {
     @State private var showCreateTemplate = false
     @State private var templateToDelete: Template?
     @State private var showDeleteConfirmation = false
+    @State private var showShareSheet = false
+    @StateObject private var shareViewModel = ShareViewModel()
 
     private let columns = [
         GridItem(.flexible(), spacing: AppSpacing.sm),
@@ -54,6 +56,24 @@ struct TemplateListView: View {
                 }
             } message: {
                 Text("Are you sure you want to delete this template? This cannot be undone.")
+            }
+            .sheet(isPresented: $showShareSheet) {
+                if let url = shareViewModel.shareURL {
+                    ShareActivityView(activityItems: [url])
+                }
+            }
+            .onChange(of: shareViewModel.shareURL) { _, url in
+                if url != nil {
+                    showShareSheet = true
+                }
+            }
+            .alert("Sharing Error", isPresented: .init(
+                get: { shareViewModel.error != nil },
+                set: { if !$0 { shareViewModel.clearError() } }
+            )) {
+                Button("OK") { shareViewModel.clearError() }
+            } message: {
+                Text(shareViewModel.error ?? "")
             }
             .refreshable {
                 await viewModel.refreshAsync()
@@ -118,6 +138,12 @@ struct TemplateListView: View {
                                 viewModel.duplicateTemplate(template)
                             } label: {
                                 Label("Duplicate", systemImage: "doc.on.doc")
+                            }
+
+                            Button {
+                                shareViewModel.createShare(type: "template", itemId: template.serverId)
+                            } label: {
+                                Label("Share", systemImage: "square.and.arrow.up")
                             }
 
                             Divider()

--- a/NippardationTests/Sharing/DeepLinkRouterTests.swift
+++ b/NippardationTests/Sharing/DeepLinkRouterTests.swift
@@ -1,0 +1,104 @@
+//
+//  DeepLinkRouterTests.swift
+//  NippardationTests
+//
+//  Tests for DeepLinkRouter URL parsing
+//
+
+import Testing
+import Foundation
+@testable import Nippardation
+
+@Suite struct DeepLinkRouterTests {
+
+    // MARK: - Token Extraction (static, no MainActor needed)
+
+    @Test func extractsTokenFromValidShareURL() {
+        let url = URL(string: "nippardation://share/abc123")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == "abc123")
+    }
+
+    @Test func extractsTokenWithLongAlphanumericToken() {
+        let url = URL(string: "nippardation://share/a3Bf9kLm2xQz")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == "a3Bf9kLm2xQz")
+    }
+
+    @Test func returnsNilForWrongScheme() {
+        let url = URL(string: "https://share/abc123")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == nil)
+    }
+
+    @Test func returnsNilForMissingToken() {
+        let url = URL(string: "nippardation://share/")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == nil)
+    }
+
+    @Test func returnsNilForWrongHost() {
+        let url = URL(string: "nippardation://other/abc123")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == nil)
+    }
+
+    @Test func returnsNilForEmptyURL() {
+        let url = URL(string: "nippardation://")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == nil)
+    }
+
+    @Test func returnsNilForSchemeOnly() {
+        let url = URL(string: "nippardation:///")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == nil)
+    }
+
+    @Test func handlesTokenWithHyphens() {
+        let url = URL(string: "nippardation://share/abc-123-def")!
+        let token = DeepLinkRouter.extractShareToken(from: url)
+        #expect(token == "abc-123-def")
+    }
+
+    // MARK: - handleURL (requires MainActor)
+
+    @MainActor
+    @Test func handleURLSetsPendingToken() async {
+        let router = DeepLinkRouter.shared
+        router.clearPendingToken()
+
+        let url = URL(string: "nippardation://share/test123")!
+        let handled = router.handleURL(url)
+
+        #expect(handled == true)
+        #expect(router.pendingShareToken == "test123")
+
+        // Cleanup
+        router.clearPendingToken()
+    }
+
+    @MainActor
+    @Test func handleURLReturnsFalseForInvalidURL() async {
+        let router = DeepLinkRouter.shared
+        router.clearPendingToken()
+
+        let url = URL(string: "https://example.com/share/test")!
+        let handled = router.handleURL(url)
+
+        #expect(handled == false)
+        #expect(router.pendingShareToken == nil)
+    }
+
+    @MainActor
+    @Test func clearPendingTokenResetsState() async {
+        let router = DeepLinkRouter.shared
+
+        let url = URL(string: "nippardation://share/clear_test")!
+        _ = router.handleURL(url)
+        #expect(router.pendingShareToken != nil)
+
+        router.clearPendingToken()
+        #expect(router.pendingShareToken == nil)
+    }
+}

--- a/NippardationTests/Sharing/ShareAPIServiceTests.swift
+++ b/NippardationTests/Sharing/ShareAPIServiceTests.swift
@@ -1,0 +1,182 @@
+//
+//  ShareAPIServiceTests.swift
+//  NippardationTests
+//
+//  Tests for ShareAPIService
+//
+
+import Testing
+import Foundation
+@testable import Nippardation
+
+@Suite(.serialized)
+struct ShareAPIServiceTests {
+
+    private func createService(authProvider: AuthTokenProviding = MockAuthTokenProvider()) -> (ShareAPIService, String) {
+        let sessionID = MockURLProtocol.makeSessionID()
+        MockURLProtocol.reset(sessionID: sessionID)
+        return (ShareAPIService(session: MockURLProtocol.mockSession(sessionID: sessionID), authProvider: authProvider), sessionID)
+    }
+
+    // MARK: - createShare Tests
+
+    @Test func createShareBuildsCorrectRequest() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            #expect(request.url?.path.contains("api/shares") == true)
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                #expect(json["type"] as? String == "program")
+                #expect(json["itemId"] as? String == "prog_001")
+            }
+
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 401)
+        }
+
+        do {
+            _ = try await service.createShare(type: "program", itemId: "prog_001")
+        } catch {
+            // Expected — we returned 401
+        }
+    }
+
+    @Test func createShareDecodesWrappedResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let json: [String: Any] = [
+                "success": true,
+                "data": [
+                    "token": "abc123",
+                    "shareUrl": "nippardation://share/abc123",
+                    "expiresAt": NSNull()
+                ]
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let result = try await service.createShare(type: "program", itemId: "prog_001")
+        #expect(result.token == "abc123")
+        #expect(result.shareUrl == "nippardation://share/abc123")
+        #expect(result.expiresAt == nil)
+    }
+
+    @Test func createShareDecodesFlatResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let json: [String: Any] = [
+                "token": "def456",
+                "shareUrl": "nippardation://share/def456",
+                "expiresAt": NSNull()
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let result = try await service.createShare(type: "template", itemId: "tmpl_001")
+        #expect(result.token == "def456")
+    }
+
+    @Test func createShareRequiresAuth() async throws {
+        let (service, sessionID) = createService(authProvider: MockAuthTokenProvider(token: nil))
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 200)
+        }
+
+        do {
+            _ = try await service.createShare(type: "program", itemId: "prog_001")
+            Issue.record("Expected unauthorized error")
+        } catch let error as RepositoryError {
+            if case .unauthorized = error {
+                // Expected
+            } else {
+                Issue.record("Expected unauthorized, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - fetchShare Tests
+
+    @Test func fetchShareBuildsCorrectRequest() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            #expect(request.url?.path.contains("api/shares/test_token") == true)
+            #expect(request.httpMethod == "GET")
+            // fetchShare does NOT require auth
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 404)
+        }
+
+        do {
+            _ = try await service.fetchShare(token: "test_token")
+        } catch {
+            // Expected
+        }
+    }
+
+    @Test func fetchShareDecodesWrappedResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let json: [String: Any] = [
+                "success": true,
+                "data": [
+                    "token": "abc123",
+                    "type": "template",
+                    "sharedBy": [
+                        "handle": "testuser",
+                        "displayName": "Test User"
+                    ],
+                    "sharedAt": "2026-03-08T12:00:00Z",
+                    "expiresAt": NSNull(),
+                    "template": [
+                        "id": "tmpl_001",
+                        "name": "Push Day",
+                        "exercises": [] as [[String: Any]],
+                        "isPublic": false,
+                        "createdAt": "2026-01-01T00:00:00Z",
+                        "updatedAt": "2026-01-01T00:00:00Z"
+                    ] as [String: Any]
+                ] as [String: Any]
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let result = try await service.fetchShare(token: "abc123")
+        #expect(result.type == "template")
+        #expect(result.sharedBy.handle == "testuser")
+        #expect(result.sharedBy.displayName == "Test User")
+        #expect(result.template?.name == "Push Day")
+        #expect(result.program == nil)
+    }
+
+    @Test func fetchShareHandles404() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 404)
+        }
+
+        do {
+            _ = try await service.fetchShare(token: "invalid_token")
+            Issue.record("Expected notFound error")
+        } catch let error as RepositoryError {
+            if case .notFound = error {
+                // Expected
+            } else {
+                Issue.record("Expected notFound, got \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implement full outbound sharing flow: share buttons on program detail, program list, template list, and template editor views create `nippardation://share/TOKEN` links via the Share API and present the system share sheet
- Implement full inbound import flow: app registers `nippardation://` URL scheme, `DeepLinkRouter` parses incoming links, `MainTabView` presents a preview sheet with item details and sharer info, user can import programs/templates to their library
- Add `ShareAPIService` (protocol + implementation + mock) aligned to backend handoff spec, with DTOs using `handle`-based sharer identity and nullable `displayName`
- Include backend API spec document at `Nippardation/Docs/backend-share-api-spec.md`

## Test plan

- [x] Build succeeds (`xcodebuild build`)
- [x] All 18 new sharing tests pass (DeepLinkRouter URL parsing + ShareAPIService request/response)
- [x] All existing tests continue to pass
- [ ] Manual: Tap Share on a program → share sheet appears with `nippardation://share/TOKEN` URL
- [ ] Manual: Tap Share on a template → share sheet appears with URL
- [ ] Manual: Open `nippardation://share/TOKEN` in Safari → app opens, preview sheet shows shared item
- [ ] Manual: Tap Import on preview → program/templates appear in library
- [ ] Manual: Test with invalid token → "Share not found" error shown
- [ ] Manual: Test while offline → network error shown