### PR TITLE
Add AI generation improvements: template cleanup & reuse

### DIFF
--- a/Nippardation/CoreData/Extensions/CoreDataManager+Programs.swift
+++ b/Nippardation/CoreData/Extensions/CoreDataManager+Programs.swift
@@ -104,26 +104,28 @@ extension CoreDataManager {
                     cdProgram.lastFetchedAt = Date()
                     cdProgram.syncStatus = program.serverId.isEmpty ? 0 : 2 // unsynced if no serverId
 
-                    // Remove existing workouts and add new ones
-                    if let existingWorkouts = cdProgram.workouts {
-                        for case let workout as CDProgramWorkout in existingWorkouts {
-                            context.delete(workout)
+                    // Only replace workouts when the incoming program actually has them.
+                    // List endpoints may omit workouts — preserve cached data.
+                    if !program.workouts.isEmpty {
+                        if let existingWorkouts = cdProgram.workouts {
+                            for case let workout as CDProgramWorkout in existingWorkouts {
+                                context.delete(workout)
+                            }
                         }
-                    }
 
-                    // Add workouts
-                    let orderedWorkouts = NSMutableOrderedSet()
-                    for programWorkout in program.workouts {
-                        let cdWorkout = CDProgramWorkout(context: context)
-                        cdWorkout.id = programWorkout.id
-                        cdWorkout.serverId = programWorkout.serverId
-                        cdWorkout.dayNumber = Int16(programWorkout.dayNumber)
-                        cdWorkout.dayLabel = programWorkout.dayLabel
-                        cdWorkout.templateServerId = programWorkout.templateServerId
-                        cdWorkout.program = cdProgram
-                        orderedWorkouts.add(cdWorkout)
+                        let orderedWorkouts = NSMutableOrderedSet()
+                        for programWorkout in program.workouts {
+                            let cdWorkout = CDProgramWorkout(context: context)
+                            cdWorkout.id = programWorkout.id
+                            cdWorkout.serverId = programWorkout.serverId
+                            cdWorkout.dayNumber = Int16(programWorkout.dayNumber)
+                            cdWorkout.dayLabel = programWorkout.dayLabel
+                            cdWorkout.templateServerId = programWorkout.templateServerId
+                            cdWorkout.program = cdProgram
+                            orderedWorkouts.add(cdWorkout)
+                        }
+                        cdProgram.workouts = orderedWorkouts
                     }
-                    cdProgram.workouts = orderedWorkouts
 
                     try context.save()
                     continuation.resume()

--- a/Nippardation/CoreData/Extensions/CoreDataManager+Templates.swift
+++ b/Nippardation/CoreData/Extensions/CoreDataManager+Templates.swift
@@ -82,30 +82,32 @@ extension CoreDataManager {
                     cdTemplate.lastFetchedAt = Date()
                     cdTemplate.syncStatus = template.serverId.isEmpty ? 0 : 2 // unsynced if no serverId
 
-                    // Remove existing exercises and add new ones
-                    if let existingExercises = cdTemplate.exercises {
-                        for case let exercise as CDTemplateExercise in existingExercises {
-                            context.delete(exercise)
+                    // Only replace exercises when the incoming template actually has them.
+                    // List endpoints return templates without exercises — preserve cached data.
+                    if !template.exercises.isEmpty {
+                        if let existingExercises = cdTemplate.exercises {
+                            for case let exercise as CDTemplateExercise in existingExercises {
+                                context.delete(exercise)
+                            }
                         }
-                    }
 
-                    // Add exercises
-                    let orderedExercises = NSMutableOrderedSet()
-                    for templateExercise in template.exercises {
-                        let cdExercise = CDTemplateExercise(context: context)
-                        cdExercise.id = templateExercise.id
-                        cdExercise.serverId = templateExercise.serverId
-                        cdExercise.exerciseServerId = templateExercise.exerciseServerId
-                        cdExercise.orderIndex = Int16(templateExercise.orderIndex)
-                        cdExercise.warmupSets = Int16(templateExercise.warmupSets ?? 0)
-                        cdExercise.workingSets = Int16(templateExercise.workingSets)
-                        cdExercise.targetReps = templateExercise.targetReps
-                        cdExercise.restSeconds = Int16(templateExercise.restSeconds ?? 0)
-                        cdExercise.notes = templateExercise.notes
-                        cdExercise.template = cdTemplate
-                        orderedExercises.add(cdExercise)
+                        let orderedExercises = NSMutableOrderedSet()
+                        for templateExercise in template.exercises {
+                            let cdExercise = CDTemplateExercise(context: context)
+                            cdExercise.id = templateExercise.id
+                            cdExercise.serverId = templateExercise.serverId
+                            cdExercise.exerciseServerId = templateExercise.exerciseServerId
+                            cdExercise.orderIndex = Int16(templateExercise.orderIndex)
+                            cdExercise.warmupSets = Int16(templateExercise.warmupSets ?? 0)
+                            cdExercise.workingSets = Int16(templateExercise.workingSets)
+                            cdExercise.targetReps = templateExercise.targetReps
+                            cdExercise.restSeconds = Int16(templateExercise.restSeconds ?? 0)
+                            cdExercise.notes = templateExercise.notes
+                            cdExercise.template = cdTemplate
+                            orderedExercises.add(cdExercise)
+                        }
+                        cdTemplate.exercises = orderedExercises
                     }
-                    cdTemplate.exercises = orderedExercises
 
                     try context.save()
                     continuation.resume()

--- a/Nippardation/DesignSystem/AIDesignTokens.swift
+++ b/Nippardation/DesignSystem/AIDesignTokens.swift
@@ -1,0 +1,205 @@
+//
+//  AIDesignTokens.swift
+//  Nippardation
+//
+//  Design tokens and reusable components for AI-powered features
+//
+
+import SwiftUI
+
+// MARK: - AI Color Palette
+
+enum AIColors {
+    static let gradientStart = Color.purple
+    static let gradientEnd = Color.indigo
+    static let accent = Color.purple
+
+    static var gradient: LinearGradient {
+        LinearGradient(
+            colors: [gradientStart, gradientEnd],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    static var subtleGradient: LinearGradient {
+        LinearGradient(
+            colors: [gradientStart.opacity(0.15), gradientEnd.opacity(0.08)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
+// MARK: - AI Gradient Button
+
+struct AIGradientButton: View {
+    let title: String
+    let icon: String?
+    let action: () -> Void
+    var isDisabled: Bool = false
+
+    init(_ title: String, icon: String? = "sparkles", isDisabled: Bool = false, action: @escaping () -> Void) {
+        self.title = title
+        self.icon = icon
+        self.isDisabled = isDisabled
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: AppSpacing.xs) {
+                if let icon {
+                    Image(systemName: icon)
+                }
+                Text(title)
+                    .fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppSpacing.sm)
+            .foregroundColor(.white)
+            .background(
+                isDisabled
+                    ? AnyShapeStyle(Color.gray)
+                    : AnyShapeStyle(AIColors.gradient)
+            )
+            .cornerRadius(AppCornerRadius.medium)
+        }
+        .disabled(isDisabled)
+    }
+}
+
+// MARK: - AI Step Indicator
+
+struct AIStepIndicator: View {
+    let totalSteps: Int
+    let currentStep: Int
+
+    var body: some View {
+        HStack(spacing: AppSpacing.xs) {
+            ForEach(0..<totalSteps, id: \.self) { step in
+                Capsule()
+                    .fill(step <= currentStep ? AnyShapeStyle(AIColors.gradient) : AnyShapeStyle(Color.secondary.opacity(0.3)))
+                    .frame(width: step == currentStep ? 24 : 8, height: 8)
+                    .animation(.spring(duration: 0.3), value: currentStep)
+            }
+        }
+    }
+}
+
+// MARK: - AI Card Style
+
+struct AIGradientCardModifier: ViewModifier {
+    var cornerRadius: CGFloat = AppCornerRadius.xl
+
+    func body(content: Content) -> some View {
+        content
+            .background(AIColors.subtleGradient)
+            .cornerRadius(cornerRadius)
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(
+                        LinearGradient(
+                            colors: [AIColors.gradientStart.opacity(0.4), AIColors.gradientEnd.opacity(0.2)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 1
+                    )
+            )
+    }
+}
+
+extension View {
+    func aiGradientCardStyle(cornerRadius: CGFloat = AppCornerRadius.xl) -> some View {
+        modifier(AIGradientCardModifier(cornerRadius: cornerRadius))
+    }
+}
+
+// MARK: - AI Section Header
+
+struct AISectionHeader: View {
+    let title: String
+    let subtitle: String?
+
+    init(_ title: String, subtitle: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xxs) {
+            HStack(spacing: AppSpacing.xs) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(AIColors.gradient)
+                Text(title)
+                    .font(.title2)
+                    .fontWeight(.bold)
+            }
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Quota Badge
+
+struct AIQuotaBadge: View {
+    let remaining: Int
+    let limit: Int
+
+    var body: some View {
+        HStack(spacing: AppSpacing.xxs) {
+            Image(systemName: "sparkles")
+                .font(.caption2)
+            Text("\(remaining)/\(limit) generations")
+                .font(.caption)
+                .fontWeight(.medium)
+        }
+        .padding(.horizontal, AppSpacing.sm)
+        .padding(.vertical, AppSpacing.xxs)
+        .foregroundColor(remaining > 0 ? AIColors.accent : .red)
+        .background(
+            (remaining > 0 ? AIColors.accent : Color.red).opacity(0.12)
+        )
+        .cornerRadius(AppCornerRadius.small)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("AI Gradient Button") {
+    VStack(spacing: AppSpacing.md) {
+        AIGradientButton("Generate Program") {}
+        AIGradientButton("No Generations Left", isDisabled: true) {}
+    }
+    .padding()
+}
+
+#Preview("AI Step Indicator") {
+    VStack(spacing: AppSpacing.lg) {
+        AIStepIndicator(totalSteps: 4, currentStep: 0)
+        AIStepIndicator(totalSteps: 4, currentStep: 1)
+        AIStepIndicator(totalSteps: 4, currentStep: 2)
+        AIStepIndicator(totalSteps: 4, currentStep: 3)
+    }
+}
+
+#Preview("AI Components") {
+    VStack(spacing: AppSpacing.md) {
+        AISectionHeader("Your Goal", subtitle: "Choose your training focus")
+        AIQuotaBadge(remaining: 2, limit: 3)
+        AIQuotaBadge(remaining: 0, limit: 3)
+
+        Text("AI Gradient Card")
+            .frame(maxWidth: .infinity)
+            .padding()
+            .aiGradientCardStyle()
+    }
+    .padding()
+}

--- a/Nippardation/Models/API/AIAPITypes.swift
+++ b/Nippardation/Models/API/AIAPITypes.swift
@@ -20,6 +20,7 @@ struct GenerateProgramRequest: Codable {
     let useTrainingHistory: Bool
     let manualStrengthData: [StrengthDataEntry]?
     let freeTextPreferences: String?
+    let reuseTemplateIds: [String]?
 }
 
 /// Individual strength data entry used in generation requests and strength profiles
@@ -71,6 +72,7 @@ struct AIGeneratedTemplateDTO: Codable {
     let name: String?
     let description: String?
     let exerciseCount: Int?
+    let wasReused: Bool?
     let exercises: [AIGeneratedExerciseDTO]?
 }
 

--- a/Nippardation/Models/API/AIAPITypes.swift
+++ b/Nippardation/Models/API/AIAPITypes.swift
@@ -1,0 +1,343 @@
+//
+//  AIAPITypes.swift
+//  Nippardation
+//
+//  Request and response types for AI program generation endpoints
+//
+
+import Foundation
+
+// MARK: - Generate Program
+
+/// Request body for POST /api/ai/generate-program
+struct GenerateProgramRequest: Codable {
+    let inspirationSource: String
+    let daysPerWeek: Int
+    let sessionDurationMinutes: Int
+    let experienceLevel: String
+    let goal: String
+    let equipment: [String]
+    let useTrainingHistory: Bool
+    let manualStrengthData: [StrengthDataEntry]?
+    let freeTextPreferences: String?
+}
+
+/// Individual strength data entry used in generation requests and strength profiles
+struct StrengthDataEntry: Codable, Identifiable {
+    var id = UUID()
+    var exerciseName: String
+    var weight: Double
+    var unit: String
+    var reps: Int
+    var sets: Int
+
+    enum CodingKeys: String, CodingKey {
+        case exerciseName, weight, unit, reps, sets
+    }
+}
+
+/// Response from POST /api/ai/generate-program
+/// Uses AI-specific DTOs since the AI endpoint returns a different structure
+/// than the regular CRUD program endpoints (no workout IDs, inline templates, etc.)
+struct GenerateProgramResponse: Codable {
+    let program: AIGeneratedProgramDTO
+    let generation: GenerationMetadataDTO
+}
+
+/// AI-generated program structure (different from regular ProgramDTO)
+struct AIGeneratedProgramDTO: Codable {
+    let id: String
+    let name: String
+    let description: String?
+    let daysPerWeek: Int
+    let durationWeeks: Int?
+    let isAiGenerated: Bool?
+    let aiPrompt: String?
+    let workouts: [AIGeneratedWorkoutDTO]?
+    let createdAt: String?
+    let updatedAt: String?
+}
+
+/// AI-generated workout (no id/templateId — template is inline)
+struct AIGeneratedWorkoutDTO: Codable {
+    let dayNumber: Int
+    let dayLabel: String?
+    let template: AIGeneratedTemplateDTO?
+}
+
+/// AI-generated template (includes exerciseCount, different exercise structure)
+struct AIGeneratedTemplateDTO: Codable {
+    let id: String?
+    let name: String?
+    let description: String?
+    let exerciseCount: Int?
+    let exercises: [AIGeneratedExerciseDTO]?
+}
+
+/// AI-generated exercise (no id/orderIndex, has name directly)
+struct AIGeneratedExerciseDTO: Codable {
+    let exerciseId: String?
+    let name: String?
+    let warmupSets: Int?
+    let workingSets: Int?
+    let targetReps: String?
+    let restSeconds: Int?
+    let notes: String?
+}
+
+/// Metadata about the AI generation process
+struct GenerationMetadataDTO: Codable {
+    let timeMs: Int?
+    let model: String?
+    let personalizationApplied: Bool?
+    let usedTrainingHistory: Bool?
+    let personalizationSource: String?
+}
+
+// MARK: - Generation Status / Quota
+
+/// Response from GET /api/ai/generation-status
+struct GenerationStatusResponse: Codable {
+    let generationsUsed: Int
+    let generationsLimit: Int
+    let generationsRemaining: Int
+    let resetsAt: String
+    let tier: String
+}
+
+// MARK: - Strength Profile
+
+/// Request body for PUT /api/ai/strength-profile
+struct StrengthProfileRequest: Codable {
+    let entries: [StrengthDataEntry]
+}
+
+/// Response from GET /api/ai/strength-profile
+struct StrengthProfileResponse: Codable {
+    let entries: [StrengthProfileEntryDTO]
+}
+
+/// A strength profile entry returned from the server (includes matched exercise ID)
+struct StrengthProfileEntryDTO: Codable {
+    let exerciseName: String
+    let weight: Double
+    let unit: String
+    let reps: Int
+    let sets: Int
+    let matchedExerciseId: String?
+}
+
+// MARK: - Enums for Picker Options
+
+/// Training goals available for AI generation
+enum AITrainingGoal: String, CaseIterable, Identifiable {
+    case hypertrophy
+    case strength
+    case endurance
+    case general
+    case powerbuilding
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .hypertrophy: return "Hypertrophy"
+        case .strength: return "Strength"
+        case .endurance: return "Endurance"
+        case .general: return "General"
+        case .powerbuilding: return "Powerbuilding"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .hypertrophy: return "figure.strengthtraining.traditional"
+        case .strength: return "dumbbell.fill"
+        case .endurance: return "heart.fill"
+        case .general: return "figure.mixed.cardio"
+        case .powerbuilding: return "bolt.fill"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .hypertrophy: return "Muscle growth"
+        case .strength: return "Max strength"
+        case .endurance: return "Stamina"
+        case .general: return "Overall fitness"
+        case .powerbuilding: return "Size & strength"
+        }
+    }
+}
+
+/// Experience levels for AI generation
+enum AIExperienceLevel: String, CaseIterable, Identifiable {
+    case beginner
+    case intermediate
+    case advanced
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .beginner: return "Beginner"
+        case .intermediate: return "Intermediate"
+        case .advanced: return "Advanced"
+        }
+    }
+}
+
+/// Equipment options for AI generation
+enum AIEquipment: String, CaseIterable, Identifiable {
+    case barbell
+    case dumbbell
+    case cable
+    case machine
+    case bodyweight
+    case bands
+    case kettlebell
+    case smith_machine
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .barbell: return "Barbell"
+        case .dumbbell: return "Dumbbell"
+        case .cable: return "Cable"
+        case .machine: return "Machine"
+        case .bodyweight: return "Bodyweight"
+        case .bands: return "Bands"
+        case .kettlebell: return "Kettlebell"
+        case .smith_machine: return "Smith Machine"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .barbell: return "figure.strengthtraining.traditional"
+        case .dumbbell: return "dumbbell.fill"
+        case .cable: return "cable.connector"
+        case .machine: return "gearshape.fill"
+        case .bodyweight: return "figure.walk"
+        case .bands: return "circle.dotted"
+        case .kettlebell: return "scalemass.fill"
+        case .smith_machine: return "square.stack.3d.up.fill"
+        }
+    }
+}
+
+/// Predefined split type suggestions
+enum AISplitSuggestion: String, CaseIterable, Identifiable {
+    case pushPullLegs = "Push Pull Legs"
+    case upperLower = "Upper Lower"
+    case fullBody = "Full Body"
+    case broSplit = "Bro Split"
+
+    var id: String { rawValue }
+}
+
+// MARK: - AI Response → Domain Model Mapping
+
+enum AIGeneratedProgramMapper {
+
+    static func toDomain(_ dto: AIGeneratedProgramDTO) -> Program {
+        let workouts = (dto.workouts ?? []).enumerated().map { index, workoutDTO in
+            toDomain(workoutDTO, index: index)
+        }
+
+        return Program(
+            id: UUID(),
+            serverId: dto.id,
+            name: dto.name,
+            description: dto.description,
+            daysPerWeek: dto.daysPerWeek,
+            durationWeeks: dto.durationWeeks,
+            workouts: workouts,
+            isActive: false,
+            currentDayIndex: 0,
+            timesCompleted: 0,
+            isPublic: false,
+            isAiGenerated: dto.isAiGenerated ?? true,
+            createdAt: parseDate(dto.createdAt) ?? Date(),
+            updatedAt: parseDate(dto.updatedAt) ?? Date(),
+            lastFetchedAt: Date()
+        )
+    }
+
+    static func toDomain(_ dto: AIGeneratedWorkoutDTO, index: Int) -> ProgramWorkout {
+        let template = dto.template.map { toDomain($0) }
+        return ProgramWorkout(
+            id: UUID(),
+            serverId: "",
+            dayNumber: dto.dayNumber,
+            dayLabel: dto.dayLabel,
+            templateServerId: dto.template?.id ?? "",
+            template: template
+        )
+    }
+
+    static func toDomain(_ dto: AIGeneratedTemplateDTO) -> Template {
+        let exercises = (dto.exercises ?? []).enumerated().map { index, exerciseDTO in
+            toDomain(exerciseDTO, orderIndex: index)
+        }
+
+        return Template(
+            id: UUID(),
+            serverId: dto.id ?? "",
+            name: dto.name ?? "Workout",
+            description: dto.description,
+            exercises: exercises,
+            isPublic: false,
+            isAiGenerated: true,
+            createdAt: Date(),
+            updatedAt: Date(),
+            lastFetchedAt: Date()
+        )
+    }
+
+    static func toDomain(_ dto: AIGeneratedExerciseDTO, orderIndex: Int) -> TemplateExercise {
+        // Create a stub ExerciseLibraryItem so displayName works
+        // (the AI response provides exercise names directly)
+        let stubLibraryItem = dto.name.map { name in
+            ExerciseLibraryItem(
+                id: UUID(),
+                serverId: dto.exerciseId ?? "",
+                name: name,
+                primaryMuscles: [],
+                secondaryMuscles: [],
+                equipment: nil,
+                difficulty: nil,
+                movementPattern: nil,
+                exerciseType: nil,
+                instructions: nil,
+                videoUrl: nil,
+                thumbnailUrl: nil,
+                popularityScore: 0,
+                lastFetchedAt: nil
+            )
+        }
+
+        return TemplateExercise(
+            id: UUID(),
+            serverId: "",
+            exerciseServerId: dto.exerciseId ?? "",
+            exerciseLibraryItem: stubLibraryItem,
+            orderIndex: orderIndex,
+            warmupSets: dto.warmupSets,
+            workingSets: dto.workingSets ?? 3,
+            targetReps: dto.targetReps,
+            restSeconds: dto.restSeconds,
+            notes: dto.notes
+        )
+    }
+
+    private static func parseDate(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+}

--- a/Nippardation/Models/API/SharedAPITypes.swift
+++ b/Nippardation/Models/API/SharedAPITypes.swift
@@ -157,6 +157,18 @@ struct TemplateSummaryDTO: Codable {
 
 }
 
+// MARK: - Delete Program Response
+
+/// Response data from DELETE /api/programs/:id?deleteTemplates=true
+struct DeleteProgramResponse: Codable {
+    let templatesRemoved: Int
+}
+
+/// Request body for DELETE /api/programs/:id?deleteTemplates=true
+struct DeleteProgramTemplatesBody: Encodable {
+    let keepTemplateIds: [String]
+}
+
 // MARK: - User Types
 
 /// User data transfer object from API

--- a/Nippardation/Models/API/TemplateDTO.swift
+++ b/Nippardation/Models/API/TemplateDTO.swift
@@ -25,11 +25,24 @@ struct TemplateDTO: Codable, Identifiable {
     let description: String?
     /// Present on full template payloads; omitted on summary payloads embedded in program responses
     let exercises: [TemplateExerciseDTO]?
+    /// Exercise count provided by list endpoints that omit the full exercises array
+    let exerciseCount: Int?
     let isPublic: Bool?
     let isAiGenerated: Bool?
     let createdAt: String?
     let updatedAt: String?
 
+    init(id: String, name: String, description: String? = nil, exercises: [TemplateExerciseDTO]? = nil, exerciseCount: Int? = nil, isPublic: Bool? = nil, isAiGenerated: Bool? = nil, createdAt: String? = nil, updatedAt: String? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.exercises = exercises
+        self.exerciseCount = exerciseCount
+        self.isPublic = isPublic
+        self.isAiGenerated = isAiGenerated
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 
 /// Template exercise data transfer object

--- a/Nippardation/Models/Domain/AIGenerationStatus.swift
+++ b/Nippardation/Models/Domain/AIGenerationStatus.swift
@@ -1,0 +1,48 @@
+//
+//  AIGenerationStatus.swift
+//  Nippardation
+//
+//  Domain model for AI generation quota information
+//
+
+import Foundation
+
+/// Represents the user's AI generation quota status
+struct AIGenerationStatus {
+    let generationsUsed: Int
+    let generationsRemaining: Int
+    let generationsLimit: Int
+    let resetsAt: Date
+    let tier: String
+
+    /// Human-readable reset date
+    var resetsAtFormatted: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: resetsAt)
+    }
+
+    /// Whether the user has generations remaining
+    var hasRemaining: Bool {
+        generationsRemaining > 0
+    }
+
+    /// Maps from API response DTO
+    static func from(_ dto: GenerationStatusResponse) -> AIGenerationStatus {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var resetDate = formatter.date(from: dto.resetsAt) ?? Date()
+        if resetDate == Date() {
+            formatter.formatOptions = [.withInternetDateTime]
+            resetDate = formatter.date(from: dto.resetsAt) ?? Date()
+        }
+
+        return AIGenerationStatus(
+            generationsUsed: dto.generationsUsed,
+            generationsRemaining: dto.generationsRemaining,
+            generationsLimit: dto.generationsLimit,
+            resetsAt: resetDate,
+            tier: dto.tier
+        )
+    }
+}

--- a/Nippardation/Models/Domain/Template.swift
+++ b/Nippardation/Models/Domain/Template.swift
@@ -25,8 +25,11 @@ struct Template: Identifiable, Hashable {
 
     /// Number of exercises in the template
     var exerciseCount: Int {
-        exercises.count
+        exercises.isEmpty ? (_knownExerciseCount ?? 0) : exercises.count
     }
+
+    /// Stored exercise count from API (used when exercises array is empty but count is known from list endpoint)
+    var _knownExerciseCount: Int? = nil
 
     /// Total number of working sets in the template
     var totalWorkingSets: Int {

--- a/Nippardation/Models/Mappers/TemplateMapper.swift
+++ b/Nippardation/Models/Mappers/TemplateMapper.swift
@@ -14,18 +14,24 @@ enum TemplateMapper {
 
     /// Converts a TemplateDTO to a Template domain model
     static func toDomain(_ dto: TemplateDTO) -> Template {
-        Template(
+        let exercises = (dto.exercises ?? []).map { TemplateExerciseMapper.toDomain($0) }
+        var template = Template(
             id: UUID(),
             serverId: dto.id,
             name: dto.name,
             description: dto.description,
-            exercises: (dto.exercises ?? []).map { TemplateExerciseMapper.toDomain($0) },
+            exercises: exercises,
             isPublic: dto.isPublic ?? false,
             isAiGenerated: dto.isAiGenerated ?? false,
             createdAt: parseDate(dto.createdAt) ?? Date(),
             updatedAt: parseDate(dto.updatedAt) ?? Date(),
             lastFetchedAt: Date()
         )
+        // Preserve exercise count from API when exercises array is empty (list endpoints)
+        if exercises.isEmpty, let count = dto.exerciseCount {
+            template._knownExerciseCount = count
+        }
+        return template
     }
 
     /// Converts multiple TemplateDTOs to Templates

--- a/Nippardation/Services/API/AIAPIService.swift
+++ b/Nippardation/Services/API/AIAPIService.swift
@@ -1,0 +1,139 @@
+//
+//  AIAPIService.swift
+//  Nippardation
+//
+//  API service for AI-powered program generation
+//
+
+import Foundation
+
+final class AIAPIService: BaseAPIService, AIAPIServiceProtocol, @unchecked Sendable {
+
+    override init(session: URLSession = .shared, authProvider: AuthTokenProviding = DefaultAuthTokenProvider.shared) {
+        super.init(session: session, authProvider: authProvider)
+    }
+
+    // MARK: - AIAPIServiceProtocol
+
+    func generateProgram(_ request: GenerateProgramRequest) async throws -> GenerateProgramResponse {
+        let url = AppConfiguration.shared.baseURL.appendingPathComponent("api/ai/generate-program")
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = try encoder.encode(request)
+        urlRequest.timeoutInterval = 120 // Generation can take 30-60s+ on the backend
+        try await addAuthHeader(to: &urlRequest)
+
+        let (data, response) = try await performRequestWithoutDecoding(urlRequest)
+
+        // Custom error handling: parse the backend's JSON error structure
+        // to extract the human-readable message instead of showing raw JSON
+        do {
+            try validateResponse(response, data: data)
+        } catch {
+            throw Self.parseAIError(from: data) ?? error
+        }
+
+        return try decodeGenerateResponse(from: data)
+    }
+
+    func fetchGenerationStatus() async throws -> GenerationStatusResponse {
+        let url = AppConfiguration.shared.baseURL.appendingPathComponent("api/ai/generation-status")
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        try await addAuthHeader(to: &urlRequest)
+
+        let (data, response) = try await performRequestWithoutDecoding(urlRequest)
+        try validateResponse(response, data: data)
+        return try decodeStatusResponse(from: data)
+    }
+
+    func saveStrengthProfile(_ request: StrengthProfileRequest) async throws {
+        let url = AppConfiguration.shared.baseURL.appendingPathComponent("api/ai/strength-profile")
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "PUT"
+        urlRequest.httpBody = try encoder.encode(request)
+        try await addAuthHeader(to: &urlRequest)
+
+        let (data, response) = try await performRequestWithoutDecoding(urlRequest)
+        try validateResponse(response, data: data)
+    }
+
+    func fetchStrengthProfile() async throws -> StrengthProfileResponse {
+        let url = AppConfiguration.shared.baseURL.appendingPathComponent("api/ai/strength-profile")
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        try await addAuthHeader(to: &urlRequest)
+
+        let (data, response) = try await performRequestWithoutDecoding(urlRequest)
+        try validateResponse(response, data: data)
+        return try decodeProfileResponse(from: data)
+    }
+
+    // MARK: - Error Parsing
+
+    /// Parses the backend's structured error JSON to extract a human-readable message.
+    /// Backend returns: {"success":false,"message":"...","correlationId":"...","retryable":true/false}
+    private static func parseAIError(from data: Data?) -> RepositoryError? {
+        guard let data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let success = json["success"] as? Bool, !success,
+              let message = json["message"] as? String else {
+            return nil
+        }
+
+        #if DEBUG
+        print("[AIAPIService] Error response: \(json)")
+        #endif
+
+        let retryable = json["retryable"] as? Bool ?? false
+        // Use 503 for retryable so RepositoryError.isRetryable returns true (statusCode >= 500)
+        let statusCode = retryable ? 503 : 500
+        return .serverError(statusCode: statusCode, message: message)
+    }
+
+    // MARK: - Response Decoding
+
+    private func decodeGenerateResponse(from data: Data) throws -> GenerateProgramResponse {
+        // Try wrapped envelope first
+        if let wrapped = try? decoder.decode(APIEnvelope<GenerateProgramResponse>.self, from: data),
+           let payload = wrapped.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(GenerateProgramResponse.self, from: data)
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+
+    private func decodeStatusResponse(from data: Data) throws -> GenerationStatusResponse {
+        if let wrapped = try? decoder.decode(APIEnvelope<GenerationStatusResponse>.self, from: data),
+           let payload = wrapped.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(GenerationStatusResponse.self, from: data)
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+
+    private func decodeProfileResponse(from data: Data) throws -> StrengthProfileResponse {
+        if let wrapped = try? decoder.decode(APIEnvelope<StrengthProfileResponse>.self, from: data),
+           let payload = wrapped.data {
+            return payload
+        }
+
+        do {
+            return try decoder.decode(StrengthProfileResponse.self, from: data)
+        } catch {
+            throw decodeFailure(error, data: data)
+        }
+    }
+}

--- a/Nippardation/Services/API/BaseAPIService.swift
+++ b/Nippardation/Services/API/BaseAPIService.swift
@@ -94,21 +94,33 @@ class BaseAPIService: @unchecked Sendable {
         case 404:
             throw RepositoryError.notFound
         case 422:
-            let message = data.flatMap { String(data: $0, encoding: .utf8) } ?? "Validation failed"
+            let message = Self.extractErrorMessage(from: data) ?? "Validation failed"
             throw RepositoryError.validationError(message)
         case 429:
             let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
                 .flatMap { Double($0) }
             throw RepositoryError.rateLimited(retryAfter: retryAfter)
         case 400...499:
-            let message = data.flatMap { String(data: $0, encoding: .utf8) }
+            let message = Self.extractErrorMessage(from: data)
             throw RepositoryError.serverError(statusCode: httpResponse.statusCode, message: message)
         case 500...599:
-            let message = data.flatMap { String(data: $0, encoding: .utf8) }
+            let message = Self.extractErrorMessage(from: data)
             throw RepositoryError.serverError(statusCode: httpResponse.statusCode, message: message)
         default:
             throw RepositoryError.unknown(nil)
         }
+    }
+
+    /// Extracts a human-readable error message from the backend's JSON response.
+    /// Backend typically returns: {"success":false,"message":"...","correlationId":"..."}
+    /// Falls back to raw string if JSON parsing fails.
+    private static func extractErrorMessage(from data: Data?) -> String? {
+        guard let data else { return nil }
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let message = json["message"] as? String {
+            return message
+        }
+        return String(data: data, encoding: .utf8)
     }
 
     // MARK: - Shared Decoding Helpers

--- a/Nippardation/Services/API/ProgramAPIService.swift
+++ b/Nippardation/Services/API/ProgramAPIService.swift
@@ -137,7 +137,21 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         request.httpMethod = "DELETE"
         try await addAuthHeader(to: &request)
 
+        #if DEBUG
+        print("[ProgramAPI] DELETE \(url.absoluteString)")
+        #endif
+
         let (data, response) = try await performRequestWithoutDecoding(request)
+
+        #if DEBUG
+        if let httpResponse = response as? HTTPURLResponse {
+            print("[ProgramAPI] DELETE status: \(httpResponse.statusCode)")
+            if let body = String(data: data, encoding: .utf8) {
+                print("[ProgramAPI] DELETE response: \(body)")
+            }
+        }
+        #endif
+
         try validateResponse(response, data: data)
     }
 

--- a/Nippardation/Services/API/ProgramAPIService.swift
+++ b/Nippardation/Services/API/ProgramAPIService.swift
@@ -155,6 +155,43 @@ final class ProgramAPIService: BaseAPIService, ProgramAPIServiceProtocol, @unche
         try validateResponse(response, data: data)
     }
 
+    func deleteProgram(id: String, deleteTemplates: Bool, keepTemplateIds: [String]) async throws -> Int {
+        guard var components = URLComponents(
+            url: AppConfiguration.shared.baseURL
+                .appendingPathComponent("api/programs")
+                .appendingPathComponent(id),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw RepositoryError.unknown(nil)
+        }
+
+        if deleteTemplates {
+            components.queryItems = [URLQueryItem(name: "deleteTemplates", value: "true")]
+        }
+
+        guard let url = components.url else {
+            throw RepositoryError.unknown(nil)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        try await addAuthHeader(to: &request)
+
+        if !keepTemplateIds.isEmpty {
+            request.httpBody = try encoder.encode(DeleteProgramTemplatesBody(keepTemplateIds: keepTemplateIds))
+        }
+
+        let (data, response) = try await performRequestWithoutDecoding(request)
+        try validateResponse(response, data: data)
+
+        // Try to extract templatesRemoved from response
+        if let envelope = try? decoder.decode(APIEnvelope<DeleteProgramResponse>.self, from: data),
+           let payload = envelope.data {
+            return payload.templatesRemoved
+        }
+        return 0
+    }
+
     // MARK: - State Management
 
     func activateProgram(id: String) async throws -> ProgramDTO {

--- a/Nippardation/Services/API/TemplateAPIService.swift
+++ b/Nippardation/Services/API/TemplateAPIService.swift
@@ -145,7 +145,7 @@ final class TemplateAPIService: BaseAPIService, TemplateAPIServiceProtocol, @unc
         // Check for 409 Conflict (template in use by program)
         if let httpResponse = response as? HTTPURLResponse,
            httpResponse.statusCode == 409 {
-            throw RepositoryError.syncConflict(localId: id, remoteId: nil)
+            throw RepositoryError.validationError("This template is used by a program. Delete the program first, then try again.")
         }
 
         try validateResponse(response, data: data)

--- a/Nippardation/Services/DependencyContainer.swift
+++ b/Nippardation/Services/DependencyContainer.swift
@@ -59,6 +59,9 @@ final class DependencyContainer: ObservableObject {
     /// Share API service for sharing programs and templates
     @Published private(set) var shareAPIService: any ShareAPIServiceProtocol
 
+    /// AI API service for AI-powered program generation
+    @Published private(set) var aiAPIService: any AIAPIServiceProtocol
+
     // MARK: - Initialization
 
     private init() {
@@ -79,6 +82,7 @@ final class DependencyContainer: ObservableObject {
         self.syncAPIService = MockSyncAPIService()
         self.userAPIService = MockUserAPIService()
         self.shareAPIService = MockShareAPIService()
+        self.aiAPIService = MockAIAPIService()
     }
 
     // MARK: - Registration
@@ -127,6 +131,7 @@ final class DependencyContainer: ObservableObject {
         let syncAPI = SyncAPIService(authProvider: authProvider)
         let userAPI = UserAPIService(authProvider: authProvider)
         let shareAPI = ShareAPIService(authProvider: authProvider)
+        let aiAPI = AIAPIService(authProvider: authProvider)
 
         self.exerciseAPIService = exerciseAPI
         self.templateAPIService = templateAPI
@@ -134,6 +139,7 @@ final class DependencyContainer: ObservableObject {
         self.syncAPIService = syncAPI
         self.userAPIService = userAPI
         self.shareAPIService = shareAPI
+        self.aiAPIService = aiAPI
 
         // Repositories
         let workoutRepository = WorkoutRepository(coreDataManager: .shared)
@@ -176,6 +182,7 @@ final class DependencyContainer: ObservableObject {
         self.syncAPIService = MockSyncAPIService()
         self.userAPIService = MockUserAPIService()
         self.shareAPIService = MockShareAPIService()
+        self.aiAPIService = MockAIAPIService()
     }
 
     // MARK: - API Service Setters (Used by Agent A)
@@ -213,6 +220,11 @@ final class DependencyContainer: ObservableObject {
     /// Replace share API service with real implementation
     func setShareAPIService(_ service: any ShareAPIServiceProtocol) {
         self.shareAPIService = service
+    }
+
+    /// Replace AI API service with real implementation
+    func setAIAPIService(_ service: any AIAPIServiceProtocol) {
+        self.aiAPIService = service
     }
 
     /// Resets all services to their default state

--- a/Nippardation/Services/Mocks/MockAIAPIService.swift
+++ b/Nippardation/Services/Mocks/MockAIAPIService.swift
@@ -145,6 +145,7 @@ extension MockAIAPIService {
                         name: "Push Day",
                         description: "Chest, shoulders, and triceps",
                         exerciseCount: 2,
+                        wasReused: true,
                         exercises: [
                             AIGeneratedExerciseDTO(exerciseId: "ex_bench", name: "Bench Press", warmupSets: 2, workingSets: 4, targetReps: "8-10", restSeconds: 120, notes: nil),
                             AIGeneratedExerciseDTO(exerciseId: "ex_ohp", name: "Overhead Press", warmupSets: 1, workingSets: 3, targetReps: "8-12", restSeconds: 90, notes: nil)
@@ -159,6 +160,7 @@ extension MockAIAPIService {
                         name: "Pull Day",
                         description: "Back and biceps",
                         exerciseCount: 1,
+                        wasReused: false,
                         exercises: [
                             AIGeneratedExerciseDTO(exerciseId: "ex_row", name: "Barbell Row", warmupSets: 2, workingSets: 4, targetReps: "6-8", restSeconds: 120, notes: nil)
                         ]

--- a/Nippardation/Services/Mocks/MockAIAPIService.swift
+++ b/Nippardation/Services/Mocks/MockAIAPIService.swift
@@ -1,0 +1,179 @@
+//
+//  MockAIAPIService.swift
+//  Nippardation
+//
+//  Mock implementation of AIAPIServiceProtocol for testing and previews
+//
+
+import Foundation
+
+final class MockAIAPIService: AIAPIServiceProtocol, @unchecked Sendable {
+
+    // MARK: - Test Configuration
+
+    var shouldThrowError = false
+    var errorToThrow: RepositoryError = .networkUnavailable
+    var fetchDelay: TimeInterval = 0.1
+    var generateDelay: TimeInterval = 2.0
+
+    // MARK: - Call Tracking
+
+    private(set) var generateProgramCallCount = 0
+    private(set) var fetchGenerationStatusCallCount = 0
+    private(set) var saveStrengthProfileCallCount = 0
+    private(set) var fetchStrengthProfileCallCount = 0
+
+    private(set) var lastGenerateRequest: GenerateProgramRequest?
+
+    // MARK: - Protocol Implementation
+
+    func generateProgram(_ request: GenerateProgramRequest) async throws -> GenerateProgramResponse {
+        generateProgramCallCount += 1
+        lastGenerateRequest = request
+
+        if generateDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(generateDelay * 1_000_000_000))
+        }
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+
+        return Self.sampleGenerateResponse
+    }
+
+    func fetchGenerationStatus() async throws -> GenerationStatusResponse {
+        fetchGenerationStatusCallCount += 1
+
+        if fetchDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(fetchDelay * 1_000_000_000))
+        }
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+
+        return Self.sampleGenerationStatus
+    }
+
+    func saveStrengthProfile(_ request: StrengthProfileRequest) async throws {
+        saveStrengthProfileCallCount += 1
+
+        if fetchDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(fetchDelay * 1_000_000_000))
+        }
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+    }
+
+    func fetchStrengthProfile() async throws -> StrengthProfileResponse {
+        fetchStrengthProfileCallCount += 1
+
+        if fetchDelay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(fetchDelay * 1_000_000_000))
+        }
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+
+        return Self.sampleStrengthProfile
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        generateProgramCallCount = 0
+        fetchGenerationStatusCallCount = 0
+        saveStrengthProfileCallCount = 0
+        fetchStrengthProfileCallCount = 0
+        lastGenerateRequest = nil
+        shouldThrowError = false
+    }
+}
+
+// MARK: - Sample Data
+
+extension MockAIAPIService {
+
+    static let sampleGenerationStatus = GenerationStatusResponse(
+        generationsUsed: 1,
+        generationsLimit: 3,
+        generationsRemaining: 2,
+        resetsAt: "2026-04-01T00:00:00.000Z",
+        tier: "free"
+    )
+
+    static let sampleStrengthProfile = StrengthProfileResponse(
+        entries: [
+            StrengthProfileEntryDTO(
+                exerciseName: "Bench Press",
+                weight: 185,
+                unit: "lb",
+                reps: 8,
+                sets: 3,
+                matchedExerciseId: "ex_bench"
+            ),
+            StrengthProfileEntryDTO(
+                exerciseName: "Squat",
+                weight: 225,
+                unit: "lb",
+                reps: 5,
+                sets: 3,
+                matchedExerciseId: "ex_squat"
+            )
+        ]
+    )
+
+    static let sampleGenerateResponse = GenerateProgramResponse(
+        program: AIGeneratedProgramDTO(
+            id: "ai_prog_001",
+            name: "AI Hypertrophy Program",
+            description: "A personalized 4-day hypertrophy program.",
+            daysPerWeek: 4,
+            durationWeeks: 8,
+            isAiGenerated: true,
+            aiPrompt: "Push Pull Legs",
+            workouts: [
+                AIGeneratedWorkoutDTO(
+                    dayNumber: 0,
+                    dayLabel: "Push Day",
+                    template: AIGeneratedTemplateDTO(
+                        id: "ai_tmpl_001",
+                        name: "Push Day",
+                        description: "Chest, shoulders, and triceps",
+                        exerciseCount: 2,
+                        exercises: [
+                            AIGeneratedExerciseDTO(exerciseId: "ex_bench", name: "Bench Press", warmupSets: 2, workingSets: 4, targetReps: "8-10", restSeconds: 120, notes: nil),
+                            AIGeneratedExerciseDTO(exerciseId: "ex_ohp", name: "Overhead Press", warmupSets: 1, workingSets: 3, targetReps: "8-12", restSeconds: 90, notes: nil)
+                        ]
+                    )
+                ),
+                AIGeneratedWorkoutDTO(
+                    dayNumber: 1,
+                    dayLabel: "Pull Day",
+                    template: AIGeneratedTemplateDTO(
+                        id: "ai_tmpl_002",
+                        name: "Pull Day",
+                        description: "Back and biceps",
+                        exerciseCount: 1,
+                        exercises: [
+                            AIGeneratedExerciseDTO(exerciseId: "ex_row", name: "Barbell Row", warmupSets: 2, workingSets: 4, targetReps: "6-8", restSeconds: 120, notes: nil)
+                        ]
+                    )
+                )
+            ],
+            createdAt: "2026-03-23T00:00:00Z",
+            updatedAt: "2026-03-23T00:00:00Z"
+        ),
+        generation: GenerationMetadataDTO(
+            timeMs: 15000,
+            model: "claude-sonnet-4-5-20250514",
+            personalizationApplied: true,
+            usedTrainingHistory: false,
+            personalizationSource: "none"
+        )
+    )
+}

--- a/Nippardation/Services/Mocks/MockProgramAPIService.swift
+++ b/Nippardation/Services/Mocks/MockProgramAPIService.swift
@@ -251,6 +251,22 @@ final class MockProgramAPIService: ProgramAPIServiceProtocol, @unchecked Sendabl
         }
     }
 
+    func deleteProgram(id: String, deleteTemplates: Bool, keepTemplateIds: [String]) async throws -> Int {
+        deleteProgramCallCount += 1
+
+        if shouldThrowError {
+            throw errorToThrow
+        }
+
+        programDTOs.removeAll { $0.id == id }
+
+        if activeProgramDTO?.program.id == id {
+            activeProgramDTO = nil
+        }
+
+        return deleteTemplates ? 3 : 0
+    }
+
     // MARK: - State Management
 
     func activateProgram(id: String) async throws -> ProgramDTO {

--- a/Nippardation/Services/Mocks/MockProgramRepository.swift
+++ b/Nippardation/Services/Mocks/MockProgramRepository.swift
@@ -92,6 +92,11 @@ final class MockProgramRepository: ProgramRepositoryProtocol {
         programs.removeAll { $0.serverId == serverId }
     }
 
+    func deleteProgram(serverId: String, deleteTemplates: Bool, keepTemplateIds: [String], programTemplateIds: [String]) async throws {
+        try await simulateNetworkCall()
+        programs.removeAll { $0.serverId == serverId }
+    }
+
     func duplicateProgram(serverId: String) async throws -> Program {
         try await simulateNetworkCall()
         guard let original = programs.first(where: { $0.serverId == serverId }) else {

--- a/Nippardation/Services/Protocols/AIAPIServiceProtocol.swift
+++ b/Nippardation/Services/Protocols/AIAPIServiceProtocol.swift
@@ -1,0 +1,29 @@
+//
+//  AIAPIServiceProtocol.swift
+//  Nippardation
+//
+//  Protocol for AI generation API operations
+//
+
+import Foundation
+
+/// Protocol for AI-powered program generation API operations
+protocol AIAPIServiceProtocol: Sendable {
+
+    /// Generate a complete workout program using AI
+    /// - Parameter request: Generation parameters (goal, schedule, equipment, etc.)
+    /// - Returns: Generated program with generation metadata
+    func generateProgram(_ request: GenerateProgramRequest) async throws -> GenerateProgramResponse
+
+    /// Check the user's remaining generation quota
+    /// - Returns: Quota status including remaining generations and reset date
+    func fetchGenerationStatus() async throws -> GenerationStatusResponse
+
+    /// Save or update the user's strength profile
+    /// - Parameter request: Strength data entries to save
+    func saveStrengthProfile(_ request: StrengthProfileRequest) async throws
+
+    /// Load the user's saved strength profile
+    /// - Returns: Stored strength profile with matched exercise IDs
+    func fetchStrengthProfile() async throws -> StrengthProfileResponse
+}

--- a/Nippardation/Services/Protocols/ProgramAPIServiceProtocol.swift
+++ b/Nippardation/Services/Protocols/ProgramAPIServiceProtocol.swift
@@ -64,6 +64,14 @@ protocol ProgramAPIServiceProtocol: Sendable {
     /// - Note: Workouts cascade delete, templates are preserved
     func deleteProgram(id: String) async throws
 
+    /// Delete a program with selective template cleanup
+    /// - Parameters:
+    ///   - id: The program's server ID
+    ///   - deleteTemplates: Whether to also delete associated AI templates
+    ///   - keepTemplateIds: Template IDs to preserve
+    /// - Returns: Number of templates removed
+    func deleteProgram(id: String, deleteTemplates: Bool, keepTemplateIds: [String]) async throws -> Int
+
     // MARK: - State Management
 
     /// Set a program as active (deactivates any other active program)

--- a/Nippardation/Services/Protocols/ProgramRepositoryProtocol.swift
+++ b/Nippardation/Services/Protocols/ProgramRepositoryProtocol.swift
@@ -55,6 +55,14 @@ protocol ProgramRepositoryProtocol {
     /// - Parameter serverId: The server ID of the program to delete
     func deleteProgram(serverId: String) async throws
 
+    /// Deletes a program with selective template cleanup
+    /// - Parameters:
+    ///   - serverId: The server ID of the program to delete
+    ///   - deleteTemplates: Whether to also delete associated AI templates
+    ///   - keepTemplateIds: Template IDs to preserve
+    ///   - programTemplateIds: All template IDs belonging to this program (for cache cleanup)
+    func deleteProgram(serverId: String, deleteTemplates: Bool, keepTemplateIds: [String], programTemplateIds: [String]) async throws
+
     /// Duplicates a program (creates a copy)
     /// - Parameter serverId: The server ID of the program to duplicate
     /// - Returns: The new duplicated program

--- a/Nippardation/Services/Repositories/ProgramRepository.swift
+++ b/Nippardation/Services/Repositories/ProgramRepository.swift
@@ -62,7 +62,27 @@ final class ProgramRepository: ProgramRepositoryProtocol {
                 hasMore = pagination.hasMore
             }
 
-            // Cache all programs
+            // List endpoints may omit workouts. Merge cached workout data so
+            // workout counts remain accurate and cached workouts aren't lost.
+            let cached = getCachedPrograms()
+            if !cached.isEmpty {
+                let cachedByServerId = Dictionary(
+                    cached.map { ($0.serverId, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                allPrograms = allPrograms.map { program in
+                    guard program.workouts.isEmpty,
+                          let cachedProgram = cachedByServerId[program.serverId],
+                          !cachedProgram.workouts.isEmpty else {
+                        return program
+                    }
+                    var merged = program
+                    merged.workouts = cachedProgram.workouts
+                    return merged
+                }
+            }
+
+            // Cache all programs (preserves existing workouts for list-fetched programs)
             for program in allPrograms {
                 try? await coreDataManager.cacheProgram(program)
             }

--- a/Nippardation/Services/Repositories/ProgramRepository.swift
+++ b/Nippardation/Services/Repositories/ProgramRepository.swift
@@ -215,6 +215,21 @@ final class ProgramRepository: ProgramRepositoryProtocol {
         try? await coreDataManager.deleteCachedProgram(serverId: serverId)
     }
 
+    func deleteProgram(serverId: String, deleteTemplates: Bool, keepTemplateIds: [String], programTemplateIds: [String]) async throws {
+        _ = try await apiService.deleteProgram(id: serverId, deleteTemplates: deleteTemplates, keepTemplateIds: keepTemplateIds)
+
+        // Remove program from cache
+        try? await coreDataManager.deleteCachedProgram(serverId: serverId)
+
+        // Remove templates the server deleted (those in this program but NOT in keepTemplateIds)
+        if deleteTemplates {
+            let keepSet = Set(keepTemplateIds)
+            for templateId in Set(programTemplateIds) where !keepSet.contains(templateId) {
+                try? await coreDataManager.deleteCachedTemplate(serverId: templateId)
+            }
+        }
+    }
+
     func duplicateProgram(serverId: String) async throws -> Program {
         // Fetch original program
         let original = try await fetchProgram(serverId: serverId, forceRefresh: true)

--- a/Nippardation/Services/Repositories/TemplateRepository.swift
+++ b/Nippardation/Services/Repositories/TemplateRepository.swift
@@ -62,7 +62,30 @@ final class TemplateRepository: TemplateRepositoryProtocol {
                 hasMore = pagination.hasMore
             }
 
-            // Cache all templates
+            // List endpoints may omit exercises. Merge cached exercise data so
+            // exercise counts remain accurate and cached exercises aren't lost.
+            let cached = getCachedTemplates()
+            if !cached.isEmpty {
+                let cachedByServerId = Dictionary(
+                    cached.map { ($0.serverId, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                allTemplates = allTemplates.map { template in
+                    guard template.exercises.isEmpty,
+                          let cachedTemplate = cachedByServerId[template.serverId] else {
+                        return template
+                    }
+                    var merged = template
+                    if !cachedTemplate.exercises.isEmpty {
+                        merged.exercises = cachedTemplate.exercises
+                    } else if merged._knownExerciseCount == nil {
+                        merged._knownExerciseCount = cachedTemplate._knownExerciseCount
+                    }
+                    return merged
+                }
+            }
+
+            // Cache all templates (preserves existing exercises for list-fetched templates)
             try? await coreDataManager.cacheTemplates(allTemplates)
 
             return allTemplates

--- a/Nippardation/ViewModels/AI/AIWizardViewModel.swift
+++ b/Nippardation/ViewModels/AI/AIWizardViewModel.swift
@@ -1,0 +1,296 @@
+//
+//  AIWizardViewModel.swift
+//  Nippardation
+//
+//  ViewModel for the AI program generation wizard
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class AIWizardViewModel: ObservableObject {
+
+    // MARK: - Step 1: Goal & Split
+
+    @Published var selectedGoal: AITrainingGoal = .hypertrophy
+    @Published var inspirationSource: String = ""
+    @Published var selectedSplitSuggestion: AISplitSuggestion?
+
+    // MARK: - Step 2: Schedule
+
+    @Published var daysPerWeek: Int = 4
+    @Published var sessionDurationMinutes: Int = 60
+
+    // MARK: - Step 3: Equipment & Experience
+
+    @Published var selectedEquipment: Set<AIEquipment> = [.barbell, .dumbbell, .cable]
+    @Published var experienceLevel: AIExperienceLevel = .intermediate
+
+    // MARK: - Step 4: Preferences
+
+    @Published var freeTextPreferences: String = ""
+    @Published var useTrainingHistory: Bool = false
+    @Published var strengthEntries: [StrengthDataEntry] = []
+
+    // MARK: - Generation State
+
+    @Published var isGenerating = false
+    @Published var isLoadingQuota = false
+    @Published var isLoadingProfile = false
+    @Published var generationStatus: AIGenerationStatus?
+    @Published var generatedProgram: Program?
+    @Published var generationMetadata: GenerationMetadataDTO?
+    @Published var error: String?
+    @Published var errorIsRetryable = false
+    @Published var generationComplete = false
+
+    // MARK: - Loading Messages
+
+    @Published var loadingMessageIndex = 0
+    let loadingMessages = [
+        "Analyzing your goals...",
+        "Selecting exercises...",
+        "Building your program...",
+        "Optimizing your split...",
+        "Fine-tuning volume...",
+        "Almost there..."
+    ]
+
+    // MARK: - Dependencies
+
+    private let aiAPIService: any AIAPIServiceProtocol
+    private let programRepository: any ProgramRepositoryProtocol
+    private var generateTask: Task<Void, Never>?
+    private var loadingTimer: Timer?
+
+    // MARK: - Validation
+
+    var isStep1Valid: Bool {
+        // Must have a goal selected (always true since it has a default)
+        // inspirationSource (split preference) is optional but encouraged
+        true
+    }
+
+    var isStep2Valid: Bool {
+        daysPerWeek >= 1 && daysPerWeek <= 7 &&
+        sessionDurationMinutes >= 30 && sessionDurationMinutes <= 120
+    }
+
+    var isStep3Valid: Bool {
+        !selectedEquipment.isEmpty
+    }
+
+    var isStep4Valid: Bool {
+        generationStatus?.hasRemaining ?? true
+    }
+
+    var canGenerate: Bool {
+        isStep1Valid && isStep2Valid && isStep3Valid && isStep4Valid && !isGenerating
+    }
+
+    // MARK: - Initialization
+
+    init(
+        aiAPIService: (any AIAPIServiceProtocol)? = nil,
+        programRepository: (any ProgramRepositoryProtocol)? = nil
+    ) {
+        self.aiAPIService = aiAPIService ?? DependencyContainer.shared.aiAPIService
+        self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+    }
+
+    // MARK: - Public Methods
+
+    func loadQuota() {
+        Task {
+            isLoadingQuota = true
+            do {
+                let status = try await aiAPIService.fetchGenerationStatus()
+                generationStatus = AIGenerationStatus.from(status)
+            } catch {
+                // Non-critical: allow user to proceed even if quota check fails
+                #if DEBUG
+                print("Failed to fetch generation status: \(error)")
+                #endif
+            }
+            isLoadingQuota = false
+        }
+    }
+
+    func loadStrengthProfile() {
+        Task {
+            isLoadingProfile = true
+            do {
+                let profile = try await aiAPIService.fetchStrengthProfile()
+                strengthEntries = profile.entries.map { entry in
+                    StrengthDataEntry(
+                        exerciseName: entry.exerciseName,
+                        weight: entry.weight,
+                        unit: entry.unit,
+                        reps: entry.reps,
+                        sets: entry.sets
+                    )
+                }
+            } catch {
+                // Non-critical: user can enter data manually
+                #if DEBUG
+                print("Failed to fetch strength profile: \(error)")
+                #endif
+            }
+            isLoadingProfile = false
+        }
+    }
+
+    func selectSplitSuggestion(_ suggestion: AISplitSuggestion) {
+        if selectedSplitSuggestion == suggestion {
+            selectedSplitSuggestion = nil
+            inspirationSource = ""
+        } else {
+            selectedSplitSuggestion = suggestion
+            inspirationSource = suggestion.rawValue
+        }
+    }
+
+    func addStrengthEntry() {
+        guard strengthEntries.count < 20 else { return }
+        strengthEntries.append(StrengthDataEntry(
+            exerciseName: "",
+            weight: 0,
+            unit: "lb",
+            reps: 0,
+            sets: 0
+        ))
+    }
+
+    func removeStrengthEntry(at offsets: IndexSet) {
+        strengthEntries.remove(atOffsets: offsets)
+    }
+
+    func generate() {
+        guard canGenerate else { return }
+
+        isGenerating = true
+        error = nil
+        loadingMessageIndex = 0
+        startLoadingMessages()
+
+        generateTask = Task { [weak self] in
+            guard let self = self else { return }
+
+            // Build the inspirationSource: combine split suggestion with any custom text
+            let source = self.inspirationSource.trimmingCharacters(in: .whitespaces)
+            let finalInspirationSource = source.isEmpty ? self.selectedGoal.displayName : source
+
+            // Filter out empty strength entries
+            let validStrengthData = self.strengthEntries.filter { !$0.exerciseName.isEmpty && $0.weight > 0 }
+
+            let request = GenerateProgramRequest(
+                inspirationSource: finalInspirationSource,
+                daysPerWeek: self.daysPerWeek,
+                sessionDurationMinutes: self.sessionDurationMinutes,
+                experienceLevel: self.experienceLevel.rawValue,
+                goal: self.selectedGoal.rawValue,
+                equipment: self.selectedEquipment.map(\.rawValue),
+                useTrainingHistory: self.useTrainingHistory,
+                manualStrengthData: validStrengthData.isEmpty ? nil : validStrengthData,
+                freeTextPreferences: self.freeTextPreferences.isEmpty ? nil : self.freeTextPreferences
+            )
+
+            do {
+                let response = try await self.aiAPIService.generateProgram(request)
+
+                // Map the AI-specific DTO to a domain model
+                let program = AIGeneratedProgramMapper.toDomain(response.program)
+
+                // Cache the generated program locally
+                try? await self.programRepository.cacheProgram(program)
+
+                await MainActor.run {
+                    self.generatedProgram = program
+                    self.generationMetadata = response.generation
+                    self.isGenerating = false
+                    self.generationComplete = true
+                    self.stopLoadingMessages()
+
+                    // Update quota after successful generation
+                    if var status = self.generationStatus {
+                        self.generationStatus = AIGenerationStatus(
+                            generationsUsed: status.generationsUsed + 1,
+                            generationsRemaining: max(0, status.generationsRemaining - 1),
+                            generationsLimit: status.generationsLimit,
+                            resetsAt: status.resetsAt,
+                            tier: status.tier
+                        )
+                    }
+                }
+
+                // Save strength data if provided
+                if !validStrengthData.isEmpty {
+                    try? await self.aiAPIService.saveStrengthProfile(
+                        StrengthProfileRequest(entries: validStrengthData)
+                    )
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    self.isGenerating = false
+                    self.stopLoadingMessages()
+                }
+            } catch let repoError as RepositoryError {
+                await MainActor.run {
+                    self.isGenerating = false
+                    self.stopLoadingMessages()
+                    self.error = repoError.errorDescription
+                    self.errorIsRetryable = repoError.isRetryable
+                }
+            } catch {
+                await MainActor.run {
+                    self.isGenerating = false
+                    self.stopLoadingMessages()
+                    self.error = "Failed to generate program. Please try again."
+                    self.errorIsRetryable = true
+                }
+            }
+        }
+    }
+
+    func cancelGeneration() {
+        generateTask?.cancel()
+        generateTask = nil
+        isGenerating = false
+        stopLoadingMessages()
+    }
+
+    func clearError() {
+        error = nil
+        errorIsRetryable = false
+    }
+
+    func discardGeneratedProgram() {
+        guard let program = generatedProgram else { return }
+
+        Task {
+            // Clean up the server-side program
+            try? await programRepository.deleteProgram(serverId: program.serverId)
+        }
+
+        generatedProgram = nil
+        generationMetadata = nil
+        generationComplete = false
+    }
+
+    // MARK: - Private
+
+    private func startLoadingMessages() {
+        loadingTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.isGenerating else { return }
+                self.loadingMessageIndex = (self.loadingMessageIndex + 1) % self.loadingMessages.count
+            }
+        }
+    }
+
+    private func stopLoadingMessages() {
+        loadingTimer?.invalidate()
+        loadingTimer = nil
+    }
+}

--- a/Nippardation/ViewModels/AI/AIWizardViewModel.swift
+++ b/Nippardation/ViewModels/AI/AIWizardViewModel.swift
@@ -33,6 +33,14 @@ final class AIWizardViewModel: ObservableObject {
     @Published var useTrainingHistory: Bool = false
     @Published var strengthEntries: [StrengthDataEntry] = []
 
+    // MARK: - Template Reuse
+
+    @Published var reuseTemplates: Bool = false
+    @Published var selectedTemplateIds: Set<String> = []
+    @Published var availableTemplates: [Template] = []
+    @Published var isLoadingTemplates = false
+    @Published var reusedTemplateIds: Set<String> = []
+
     // MARK: - Generation State
 
     @Published var isGenerating = false
@@ -61,6 +69,7 @@ final class AIWizardViewModel: ObservableObject {
 
     private let aiAPIService: any AIAPIServiceProtocol
     private let programRepository: any ProgramRepositoryProtocol
+    private let templateRepository: any TemplateRepositoryProtocol
     private var generateTask: Task<Void, Never>?
     private var loadingTimer: Timer?
 
@@ -93,10 +102,12 @@ final class AIWizardViewModel: ObservableObject {
 
     init(
         aiAPIService: (any AIAPIServiceProtocol)? = nil,
-        programRepository: (any ProgramRepositoryProtocol)? = nil
+        programRepository: (any ProgramRepositoryProtocol)? = nil,
+        templateRepository: (any TemplateRepositoryProtocol)? = nil
     ) {
         self.aiAPIService = aiAPIService ?? DependencyContainer.shared.aiAPIService
         self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+        self.templateRepository = templateRepository ?? DependencyContainer.shared.templateRepository
     }
 
     // MARK: - Public Methods
@@ -166,6 +177,37 @@ final class AIWizardViewModel: ObservableObject {
         strengthEntries.remove(atOffsets: offsets)
     }
 
+    // MARK: - Template Reuse
+
+    func loadTemplates() {
+        guard !isLoadingTemplates else { return }
+        isLoadingTemplates = true
+
+        Task {
+            do {
+                let templates = try await templateRepository.fetchTemplates(forceRefresh: false)
+                await MainActor.run {
+                    self.availableTemplates = templates
+                    self.isLoadingTemplates = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.availableTemplates = []
+                    self.isLoadingTemplates = false
+                }
+            }
+        }
+    }
+
+    func toggleTemplateSelection(_ templateId: String) {
+        if selectedTemplateIds.contains(templateId) {
+            selectedTemplateIds.remove(templateId)
+        } else {
+            guard selectedTemplateIds.count < 7 else { return }
+            selectedTemplateIds.insert(templateId)
+        }
+    }
+
     func generate() {
         guard canGenerate else { return }
 
@@ -184,6 +226,9 @@ final class AIWizardViewModel: ObservableObject {
             // Filter out empty strength entries
             let validStrengthData = self.strengthEntries.filter { !$0.exerciseName.isEmpty && $0.weight > 0 }
 
+            let reuseIds = self.reuseTemplates && !self.selectedTemplateIds.isEmpty
+                ? Array(self.selectedTemplateIds) : nil
+
             let request = GenerateProgramRequest(
                 inspirationSource: finalInspirationSource,
                 daysPerWeek: self.daysPerWeek,
@@ -193,7 +238,8 @@ final class AIWizardViewModel: ObservableObject {
                 equipment: self.selectedEquipment.map(\.rawValue),
                 useTrainingHistory: self.useTrainingHistory,
                 manualStrengthData: validStrengthData.isEmpty ? nil : validStrengthData,
-                freeTextPreferences: self.freeTextPreferences.isEmpty ? nil : self.freeTextPreferences
+                freeTextPreferences: self.freeTextPreferences.isEmpty ? nil : self.freeTextPreferences,
+                reuseTemplateIds: reuseIds
             )
 
             do {
@@ -202,12 +248,26 @@ final class AIWizardViewModel: ObservableObject {
                 // Map the AI-specific DTO to a domain model
                 let program = AIGeneratedProgramMapper.toDomain(response.program)
 
-                // Cache the generated program locally
+                // Extract reused template IDs from the response
+                let reusedIds = Set(
+                    (response.program.workouts ?? [])
+                        .compactMap { $0.template }
+                        .filter { $0.wasReused == true }
+                        .compactMap { $0.id }
+                )
+
+                // Cache the generated program and its templates locally
                 try? await self.programRepository.cacheProgram(program)
+                for workout in program.workouts {
+                    if let template = workout.template {
+                        try? await self.templateRepository.cacheTemplate(template)
+                    }
+                }
 
                 await MainActor.run {
                     self.generatedProgram = program
                     self.generationMetadata = response.generation
+                    self.reusedTemplateIds = reusedIds
                     self.isGenerating = false
                     self.generationComplete = true
                     self.stopLoadingMessages()

--- a/Nippardation/ViewModels/AI/GeneratedProgramPreviewViewModel.swift
+++ b/Nippardation/ViewModels/AI/GeneratedProgramPreviewViewModel.swift
@@ -45,21 +45,27 @@ final class GeneratedProgramPreviewViewModel: ObservableObject {
 
     let originalProgram: Program
     let metadata: GenerationMetadataDTO?
+    let reusedTemplateIds: Set<String>
 
     // MARK: - Dependencies
 
     private let programRepository: any ProgramRepositoryProtocol
+    private let templateRepository: any TemplateRepositoryProtocol
 
     // MARK: - Initialization
 
     init(
         program: Program,
         metadata: GenerationMetadataDTO?,
-        programRepository: (any ProgramRepositoryProtocol)? = nil
+        reusedTemplateIds: Set<String> = [],
+        programRepository: (any ProgramRepositoryProtocol)? = nil,
+        templateRepository: (any TemplateRepositoryProtocol)? = nil
     ) {
         self.originalProgram = program
         self.metadata = metadata
+        self.reusedTemplateIds = reusedTemplateIds
         self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+        self.templateRepository = templateRepository ?? DependencyContainer.shared.templateRepository
 
         self.programName = program.name
         self.programDescription = program.description ?? ""
@@ -141,8 +147,13 @@ final class GeneratedProgramPreviewViewModel: ObservableObject {
                     _ = try await self.programRepository.updateProgram(updatedProgram)
                 }
 
-                // Cache the program locally
+                // Cache the program and its templates locally
                 try await self.programRepository.cacheProgram(updatedProgram)
+                for workout in updatedProgram.workouts {
+                    if let template = workout.template {
+                        try? await self.templateRepository.cacheTemplate(template)
+                    }
+                }
 
                 await MainActor.run {
                     self.isSaving = false

--- a/Nippardation/ViewModels/AI/GeneratedProgramPreviewViewModel.swift
+++ b/Nippardation/ViewModels/AI/GeneratedProgramPreviewViewModel.swift
@@ -1,0 +1,163 @@
+//
+//  GeneratedProgramPreviewViewModel.swift
+//  Nippardation
+//
+//  ViewModel for previewing and editing an AI-generated program before saving
+//
+
+import Foundation
+
+@MainActor
+final class GeneratedProgramPreviewViewModel: ObservableObject {
+
+    // MARK: - Editable State
+
+    @Published var programName: String
+    @Published var programDescription: String
+    @Published var workouts: [EditableWorkout]
+
+    // MARK: - UI State
+
+    @Published var isSaving = false
+    @Published var error: String?
+    @Published var savedSuccessfully = false
+
+    // MARK: - Types
+
+    struct EditableWorkout: Identifiable {
+        let id = UUID()
+        let serverId: String
+        var dayLabel: String
+        var exercises: [EditableExercise]
+    }
+
+    struct EditableExercise: Identifiable {
+        let id = UUID()
+        let serverId: String
+        var name: String
+        var workingSets: Int
+        var targetReps: String
+        var restSeconds: Int
+        var warmupSets: Int
+    }
+
+    // MARK: - Source Data
+
+    let originalProgram: Program
+    let metadata: GenerationMetadataDTO?
+
+    // MARK: - Dependencies
+
+    private let programRepository: any ProgramRepositoryProtocol
+
+    // MARK: - Initialization
+
+    init(
+        program: Program,
+        metadata: GenerationMetadataDTO?,
+        programRepository: (any ProgramRepositoryProtocol)? = nil
+    ) {
+        self.originalProgram = program
+        self.metadata = metadata
+        self.programRepository = programRepository ?? DependencyContainer.shared.programRepository
+
+        self.programName = program.name
+        self.programDescription = program.description ?? ""
+        self.workouts = program.workouts.sorted(by: { $0.dayNumber < $1.dayNumber }).map { workout in
+            EditableWorkout(
+                serverId: workout.serverId,
+                dayLabel: workout.dayLabel ?? workout.displayName,
+                exercises: (workout.template?.exercises ?? []).sorted(by: { $0.orderIndex < $1.orderIndex }).map { exercise in
+                    EditableExercise(
+                        serverId: exercise.serverId,
+                        name: exercise.displayName,
+                        workingSets: exercise.workingSets,
+                        targetReps: exercise.targetReps ?? "8-12",
+                        restSeconds: exercise.restSeconds ?? 90,
+                        warmupSets: exercise.warmupSets ?? 0
+                    )
+                }
+            )
+        }
+    }
+
+    // MARK: - Computed
+
+    var totalExercises: Int {
+        workouts.reduce(0) { $0 + $1.exercises.count }
+    }
+
+    var generationTimeFormatted: String? {
+        guard let timeMs = metadata?.timeMs else { return nil }
+        let seconds = Double(timeMs) / 1000.0
+        return String(format: "%.1fs", seconds)
+    }
+
+    // MARK: - Edit Actions
+
+    func removeExercise(workoutIndex: Int, exerciseIndex: Int) {
+        guard workoutIndex < workouts.count,
+              exerciseIndex < workouts[workoutIndex].exercises.count else { return }
+        workouts[workoutIndex].exercises.remove(at: exerciseIndex)
+    }
+
+    func moveExercise(workoutIndex: Int, from source: IndexSet, to destination: Int) {
+        guard workoutIndex < workouts.count else { return }
+        workouts[workoutIndex].exercises.move(fromOffsets: source, toOffset: destination)
+    }
+
+    // MARK: - Save
+
+    func save() {
+        isSaving = true
+        error = nil
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                // Build updated program with edits applied
+                let updatedProgram = Program(
+                    id: self.originalProgram.id,
+                    serverId: self.originalProgram.serverId,
+                    name: self.programName,
+                    description: self.programDescription.isEmpty ? nil : self.programDescription,
+                    daysPerWeek: self.originalProgram.daysPerWeek,
+                    durationWeeks: self.originalProgram.durationWeeks,
+                    workouts: self.originalProgram.workouts,
+                    isActive: false,
+                    currentDayIndex: 0,
+                    timesCompleted: 0,
+                    isPublic: false,
+                    isAiGenerated: true,
+                    createdAt: self.originalProgram.createdAt,
+                    updatedAt: Date(),
+                    lastFetchedAt: self.originalProgram.lastFetchedAt
+                )
+
+                // Update program metadata on server if name/description changed
+                if updatedProgram.name != self.originalProgram.name ||
+                   updatedProgram.description != self.originalProgram.description {
+                    _ = try await self.programRepository.updateProgram(updatedProgram)
+                }
+
+                // Cache the program locally
+                try await self.programRepository.cacheProgram(updatedProgram)
+
+                await MainActor.run {
+                    self.isSaving = false
+                    self.savedSuccessfully = true
+                }
+            } catch {
+                await MainActor.run {
+                    self.isSaving = false
+                    self.error = "Failed to save program: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    func clearError() {
+        error = nil
+    }
+}

--- a/Nippardation/ViewModels/Programs/ProgramListViewModel.swift
+++ b/Nippardation/ViewModels/Programs/ProgramListViewModel.swift
@@ -19,6 +19,15 @@ final class ProgramListViewModel: ObservableObject {
     @Published var currentPage = 1
     @Published var hasMore = false
 
+    // MARK: - Delete State
+
+    @Published var programToDeleteDetail: Program?
+    @Published var isFetchingDeleteDetail = false
+    @Published var isDeletingProgram = false
+    @Published var showTemplateDeleteSheet = false
+    @Published var showSimpleDeleteAlert = false
+    var programToDelete: Program?
+
     // MARK: - Dependencies
 
     private let programRepository: any ProgramRepositoryProtocol
@@ -121,8 +130,49 @@ final class ProgramListViewModel: ObservableObject {
         loadPublicPrograms(loadingNextPage: true)
     }
 
-    /// Deletes a program
-    /// - Parameter program: The program to delete
+    /// Prepares to delete a program. For AI programs, fetches detail to show template selection.
+    func prepareDeleteProgram(_ program: Program) {
+        programToDelete = program
+        isFetchingDeleteDetail = true
+
+        // Always fetch detail — the list endpoint may not include isAiGenerated
+        // or full workout/template data needed for the template cleanup flow.
+        Task {
+            await taskManager.run(id: "prepareDelete") { [weak self] in
+                guard let self = self else { return }
+
+                do {
+                    let detail = try await self.programRepository.fetchProgram(
+                        serverId: program.serverId,
+                        forceRefresh: true
+                    )
+
+                    // The embedded template summaries in the program detail
+                    // don't include isAiGenerated — so we check the program itself.
+                    // The backend handles safety: only AI templates get deleted.
+                    let hasTemplates = detail.workouts.contains { $0.template != nil }
+
+                    await MainActor.run {
+                        self.isFetchingDeleteDetail = false
+                        if detail.isAiGenerated && hasTemplates {
+                            self.programToDeleteDetail = detail
+                            self.showTemplateDeleteSheet = true
+                        } else {
+                            self.showSimpleDeleteAlert = true
+                        }
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.isFetchingDeleteDetail = false
+                        // Fall back to simple delete on fetch failure
+                        self.showSimpleDeleteAlert = true
+                    }
+                }
+            }
+        }
+    }
+
+    /// Deletes a program (simple, no template cleanup)
     func deleteProgram(_ program: Program) {
         Task {
             await taskManager.run(id: "delete-\(program.serverId)") { [weak self] in
@@ -141,6 +191,52 @@ final class ProgramListViewModel: ObservableObject {
                 }
             }
         }
+    }
+
+    /// Deletes an AI program with selective template cleanup
+    func deleteProgramWithTemplates(keepTemplateIds: [String]) {
+        guard let detail = programToDeleteDetail else { return }
+
+        // Extract all template IDs from the program's workouts NOW (from the detail
+        // we already fetched) — don't rely on reading them back from cache later.
+        let allTemplateIds = Array(Set(detail.workouts.map(\.templateServerId)))
+
+        isDeletingProgram = true
+
+        Task {
+            await taskManager.run(id: "delete-\(detail.serverId)") { [weak self] in
+                guard let self = self else { return }
+
+                do {
+                    try await self.programRepository.deleteProgram(
+                        serverId: detail.serverId,
+                        deleteTemplates: true,
+                        keepTemplateIds: keepTemplateIds,
+                        programTemplateIds: allTemplateIds
+                    )
+
+                    await MainActor.run {
+                        self.programs.removeAll { $0.serverId == detail.serverId }
+                        self.isDeletingProgram = false
+                        self.programToDelete = nil
+                        self.programToDeleteDetail = nil
+                        self.showTemplateDeleteSheet = false
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.isDeletingProgram = false
+                        self.error = "Failed to delete program: \(error.localizedDescription)"
+                    }
+                }
+            }
+        }
+    }
+
+    func clearDeleteState() {
+        programToDelete = nil
+        programToDeleteDetail = nil
+        showTemplateDeleteSheet = false
+        showSimpleDeleteAlert = false
     }
 
     /// Activates a program, deactivating any currently active program

--- a/Nippardation/ViewModels/Templates/TemplateListViewModel.swift
+++ b/Nippardation/ViewModels/Templates/TemplateListViewModel.swift
@@ -38,6 +38,18 @@ final class TemplateListViewModel: ObservableObject {
 
     // MARK: - Public Methods
 
+    /// Checks if the cache differs from our in-memory list and triggers a reload.
+    /// Detects both additions (e.g., AI generation) and deletions (e.g., program delete with template cleanup).
+    func loadIfStale() {
+        let cached = templateRepository.getCachedTemplates()
+        let currentIds = Set(templates.map(\.serverId))
+        let cachedIds = Set(cached.map(\.serverId))
+
+        if currentIds != cachedIds {
+            loadTemplates(refresh: false)
+        }
+    }
+
     /// Loads templates from the repository
     /// - Parameter refresh: If true, forces a refresh from the server
     func loadTemplates(refresh: Bool = false) {

--- a/Nippardation/ViewModels/Templates/TemplateListViewModel.swift
+++ b/Nippardation/ViewModels/Templates/TemplateListViewModel.swift
@@ -69,6 +69,16 @@ final class TemplateListViewModel: ObservableObject {
 
     // MARK: - Private Methods
 
+    /// Directly updates or inserts a template in the in-memory list.
+    /// Use after a save so the list reflects the change without a full API refresh.
+    func handleTemplateSaved(_ template: Template) {
+        if let index = templates.firstIndex(where: { $0.serverId == template.serverId }) {
+            templates[index] = template
+        } else {
+            templates.insert(template, at: 0)
+        }
+    }
+
     /// Core loading logic shared between loadTemplates and refreshAsync
     /// - Parameter forceRefresh: Whether to force refresh from network
     private func performLoad(forceRefresh: Bool) async {
@@ -78,7 +88,29 @@ final class TemplateListViewModel: ObservableObject {
             let fetchedTemplates = try await templateRepository.fetchTemplates(forceRefresh: forceRefresh)
 
             await MainActor.run {
-                self.templates = fetchedTemplates
+                // Preserve exercise data from existing in-memory templates when
+                // the API list endpoint returns templates without exercises.
+                if !self.templates.isEmpty {
+                    let existingByServerId = Dictionary(
+                        self.templates.map { ($0.serverId, $0) },
+                        uniquingKeysWith: { first, _ in first }
+                    )
+                    self.templates = fetchedTemplates.map { template in
+                        guard template.exercises.isEmpty,
+                              let existing = existingByServerId[template.serverId] else {
+                            return template
+                        }
+                        var merged = template
+                        if !existing.exercises.isEmpty {
+                            merged.exercises = existing.exercises
+                        } else if merged._knownExerciseCount == nil, let count = existing._knownExerciseCount {
+                            merged._knownExerciseCount = count
+                        }
+                        return merged
+                    }
+                } else {
+                    self.templates = fetchedTemplates
+                }
                 self.error = nil
                 self.isLoading = false
             }

--- a/Nippardation/Views/AI/AIGeneratingView.swift
+++ b/Nippardation/Views/AI/AIGeneratingView.swift
@@ -1,0 +1,95 @@
+//
+//  AIGeneratingView.swift
+//  Nippardation
+//
+//  Full-screen overlay shown during AI program generation
+//
+
+import SwiftUI
+
+struct AIGeneratingView: View {
+    let messageIndex: Int
+    let messages: [String]
+    let onCancel: () -> Void
+
+    @State private var sparkleRotation: Double = 0
+    @State private var pulseScale: CGFloat = 1.0
+
+    var body: some View {
+        ZStack {
+            // Gradient background
+            LinearGradient(
+                colors: [
+                    AIColors.gradientStart.opacity(0.95),
+                    AIColors.gradientEnd.opacity(0.95)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: AppSpacing.xl) {
+                Spacer()
+
+                // Animated sparkles icon
+                Image(systemName: "sparkles")
+                    .font(.system(size: 60))
+                    .foregroundColor(.white)
+                    .rotationEffect(.degrees(sparkleRotation))
+                    .scaleEffect(pulseScale)
+                    .onAppear {
+                        withAnimation(.linear(duration: 8).repeatForever(autoreverses: false)) {
+                            sparkleRotation = 360
+                        }
+                        withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                            pulseScale = 1.15
+                        }
+                    }
+
+                // Loading message
+                VStack(spacing: AppSpacing.sm) {
+                    Text("Generating Your Program")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+
+                    Text(messages.indices.contains(messageIndex) ? messages[messageIndex] : "")
+                        .font(.body)
+                        .foregroundColor(.white.opacity(0.8))
+                        .animation(.easeInOut(duration: 0.3), value: messageIndex)
+                        .id(messageIndex)
+                }
+
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(.white)
+                    .scaleEffect(1.2)
+
+                Spacer()
+
+                // Cancel button
+                Button {
+                    onCancel()
+                } label: {
+                    Text("Cancel")
+                        .fontWeight(.medium)
+                        .foregroundColor(.white.opacity(0.8))
+                        .padding(.horizontal, AppSpacing.lg)
+                        .padding(.vertical, AppSpacing.sm)
+                        .background(.white.opacity(0.15))
+                        .cornerRadius(AppCornerRadius.medium)
+                }
+                .padding(.bottom, AppSpacing.xl)
+            }
+        }
+        .transition(.opacity)
+    }
+}
+
+#Preview {
+    AIGeneratingView(
+        messageIndex: 1,
+        messages: ["Analyzing your goals...", "Selecting exercises...", "Building your program..."],
+        onCancel: {}
+    )
+}

--- a/Nippardation/Views/AI/AIWizardStep1GoalView.swift
+++ b/Nippardation/Views/AI/AIWizardStep1GoalView.swift
@@ -1,0 +1,177 @@
+//
+//  AIWizardStep1GoalView.swift
+//  Nippardation
+//
+//  Step 1: Training goal and split preference selection
+//
+
+import SwiftUI
+
+struct AIWizardStep1GoalView: View {
+    @ObservedObject var viewModel: AIWizardViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.lg) {
+                AISectionHeader("What's Your Goal?", subtitle: "Choose your training focus")
+
+                // Goal selection grid
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible())
+                ], spacing: AppSpacing.sm) {
+                    ForEach(AITrainingGoal.allCases) { goal in
+                        goalCard(goal)
+                    }
+                }
+
+                Divider()
+                    .padding(.vertical, AppSpacing.xs)
+
+                // Split preference
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Text("Preferred Split")
+                        .font(.headline)
+
+                    Text("Choose a template or describe your ideal split")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    // Suggestion chips
+                    FlowLayout(spacing: AppSpacing.xs) {
+                        ForEach(AISplitSuggestion.allCases) { suggestion in
+                            splitChip(suggestion)
+                        }
+                    }
+
+                    TextField("Or type your own (e.g., \"Arnold Split\")", text: $viewModel.inspirationSource)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: viewModel.inspirationSource) { _, newValue in
+                            // Clear chip selection if user types custom text
+                            if let selected = viewModel.selectedSplitSuggestion,
+                               newValue != selected.rawValue {
+                                viewModel.selectedSplitSuggestion = nil
+                            }
+                        }
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func goalCard(_ goal: AITrainingGoal) -> some View {
+        Button {
+            withAnimation(.spring(duration: 0.2)) {
+                viewModel.selectedGoal = goal
+            }
+        } label: {
+            VStack(spacing: AppSpacing.xs) {
+                Image(systemName: goal.icon)
+                    .font(.title2)
+                    .foregroundStyle(
+                        viewModel.selectedGoal == goal
+                            ? AnyShapeStyle(AIColors.gradient)
+                            : AnyShapeStyle(Color.secondary)
+                    )
+
+                Text(goal.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+
+                Text(goal.subtitle)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(AppSpacing.md)
+            .background(
+                viewModel.selectedGoal == goal
+                    ? AIColors.subtleGradient
+                    : LinearGradient(colors: [Color(.secondarySystemBackground)], startPoint: .top, endPoint: .bottom)
+            )
+            .cornerRadius(AppCornerRadius.medium)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppCornerRadius.medium)
+                    .stroke(
+                        viewModel.selectedGoal == goal ? AIColors.accent.opacity(0.5) : Color.clear,
+                        lineWidth: 2
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func splitChip(_ suggestion: AISplitSuggestion) -> some View {
+        Button {
+            viewModel.selectSplitSuggestion(suggestion)
+        } label: {
+            Text(suggestion.rawValue)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .padding(.horizontal, AppSpacing.sm)
+                .padding(.vertical, AppSpacing.xs)
+                .foregroundColor(
+                    viewModel.selectedSplitSuggestion == suggestion ? .white : .primary
+                )
+                .background(
+                    viewModel.selectedSplitSuggestion == suggestion
+                        ? AnyShapeStyle(AIColors.gradient)
+                        : AnyShapeStyle(Color(.tertiarySystemBackground))
+                )
+                .cornerRadius(AppCornerRadius.small)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Flow Layout
+
+/// Simple flow layout for wrapping chips horizontally
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y), proposal: .unspecified)
+        }
+    }
+
+    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions: [CGPoint] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > maxWidth && currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            positions.append(CGPoint(x: currentX, y: currentY))
+            lineHeight = max(lineHeight, size.height)
+            currentX += size.width + spacing
+            maxX = max(maxX, currentX)
+        }
+
+        return (CGSize(width: maxX, height: currentY + lineHeight), positions)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AIWizardStep1GoalView(viewModel: AIWizardViewModel())
+    }
+    .withDependencies(.preview)
+}

--- a/Nippardation/Views/AI/AIWizardStep2ScheduleView.swift
+++ b/Nippardation/Views/AI/AIWizardStep2ScheduleView.swift
@@ -1,0 +1,121 @@
+//
+//  AIWizardStep2ScheduleView.swift
+//  Nippardation
+//
+//  Step 2: Training schedule (days per week and session duration)
+//
+
+import SwiftUI
+
+struct AIWizardStep2ScheduleView: View {
+    @ObservedObject var viewModel: AIWizardViewModel
+
+    private let durations = [30, 45, 60, 75, 90, 120]
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.lg) {
+                AISectionHeader("Your Schedule", subtitle: "How often and how long can you train?")
+
+                // Days per week
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Text("Days Per Week")
+                        .font(.headline)
+
+                    HStack(spacing: AppSpacing.xs) {
+                        ForEach(1...7, id: \.self) { day in
+                            dayCircle(day)
+                        }
+                    }
+
+                    Text("\(viewModel.daysPerWeek) training day\(viewModel.daysPerWeek == 1 ? "" : "s") per week")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Divider()
+                    .padding(.vertical, AppSpacing.xs)
+
+                // Session duration
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Text("Session Duration")
+                        .font(.headline)
+
+                    LazyVGrid(columns: [
+                        GridItem(.flexible()),
+                        GridItem(.flexible()),
+                        GridItem(.flexible())
+                    ], spacing: AppSpacing.sm) {
+                        ForEach(durations, id: \.self) { minutes in
+                            durationCard(minutes)
+                        }
+                    }
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func dayCircle(_ day: Int) -> some View {
+        Button {
+            withAnimation(.spring(duration: 0.2)) {
+                viewModel.daysPerWeek = day
+            }
+        } label: {
+            Text("\(day)")
+                .font(.title3)
+                .fontWeight(.semibold)
+                .frame(width: 44, height: 44)
+                .foregroundColor(viewModel.daysPerWeek == day ? .white : .primary)
+                .background(
+                    viewModel.daysPerWeek == day
+                        ? AnyShapeStyle(AIColors.gradient)
+                        : AnyShapeStyle(Color(.tertiarySystemBackground))
+                )
+                .clipShape(Circle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func durationCard(_ minutes: Int) -> some View {
+        Button {
+            withAnimation(.spring(duration: 0.2)) {
+                viewModel.sessionDurationMinutes = minutes
+            }
+        } label: {
+            VStack(spacing: AppSpacing.xxs) {
+                Text("\(minutes)")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Text("min")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppSpacing.sm)
+            .background(
+                viewModel.sessionDurationMinutes == minutes
+                    ? AIColors.subtleGradient
+                    : LinearGradient(colors: [Color(.secondarySystemBackground)], startPoint: .top, endPoint: .bottom)
+            )
+            .cornerRadius(AppCornerRadius.medium)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppCornerRadius.medium)
+                    .stroke(
+                        viewModel.sessionDurationMinutes == minutes ? AIColors.accent.opacity(0.5) : Color.clear,
+                        lineWidth: 2
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AIWizardStep2ScheduleView(viewModel: AIWizardViewModel())
+    }
+    .withDependencies(.preview)
+}

--- a/Nippardation/Views/AI/AIWizardStep3EquipmentView.swift
+++ b/Nippardation/Views/AI/AIWizardStep3EquipmentView.swift
@@ -1,0 +1,113 @@
+//
+//  AIWizardStep3EquipmentView.swift
+//  Nippardation
+//
+//  Step 3: Equipment selection and experience level
+//
+
+import SwiftUI
+
+struct AIWizardStep3EquipmentView: View {
+    @ObservedObject var viewModel: AIWizardViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.lg) {
+                AISectionHeader("Your Setup", subtitle: "Select your experience level and available equipment")
+
+                // Experience level
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Text("Experience Level")
+                        .font(.headline)
+
+                    Picker("Experience", selection: $viewModel.experienceLevel) {
+                        ForEach(AIExperienceLevel.allCases) { level in
+                            Text(level.displayName).tag(level)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Divider()
+                    .padding(.vertical, AppSpacing.xs)
+
+                // Equipment selection
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    HStack {
+                        Text("Available Equipment")
+                            .font(.headline)
+                        Spacer()
+                        Text("\(viewModel.selectedEquipment.count) selected")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    LazyVGrid(columns: [
+                        GridItem(.flexible()),
+                        GridItem(.flexible()),
+                        GridItem(.flexible()),
+                        GridItem(.flexible())
+                    ], spacing: AppSpacing.sm) {
+                        ForEach(AIEquipment.allCases) { equipment in
+                            equipmentCard(equipment)
+                        }
+                    }
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private func equipmentCard(_ equipment: AIEquipment) -> some View {
+        let isSelected = viewModel.selectedEquipment.contains(equipment)
+
+        return Button {
+            withAnimation(.spring(duration: 0.2)) {
+                if isSelected {
+                    viewModel.selectedEquipment.remove(equipment)
+                } else {
+                    viewModel.selectedEquipment.insert(equipment)
+                }
+            }
+        } label: {
+            VStack(spacing: AppSpacing.xxs) {
+                Image(systemName: equipment.icon)
+                    .font(.title3)
+                    .foregroundStyle(
+                        isSelected
+                            ? AnyShapeStyle(AIColors.gradient)
+                            : AnyShapeStyle(Color.secondary)
+                    )
+
+                Text(equipment.displayName)
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppSpacing.sm)
+            .padding(.horizontal, AppSpacing.xxs)
+            .background(
+                isSelected
+                    ? AIColors.subtleGradient
+                    : LinearGradient(colors: [Color(.secondarySystemBackground)], startPoint: .top, endPoint: .bottom)
+            )
+            .cornerRadius(AppCornerRadius.small)
+            .overlay(
+                RoundedRectangle(cornerRadius: AppCornerRadius.small)
+                    .stroke(isSelected ? AIColors.accent.opacity(0.5) : Color.clear, lineWidth: 1.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AIWizardStep3EquipmentView(viewModel: AIWizardViewModel())
+    }
+    .withDependencies(.preview)
+}

--- a/Nippardation/Views/AI/AIWizardStep4PreferencesView.swift
+++ b/Nippardation/Views/AI/AIWizardStep4PreferencesView.swift
@@ -1,0 +1,162 @@
+//
+//  AIWizardStep4PreferencesView.swift
+//  Nippardation
+//
+//  Step 4: Free-text preferences, optional strength data, and generate trigger
+//
+
+import SwiftUI
+
+struct AIWizardStep4PreferencesView: View {
+    @ObservedObject var viewModel: AIWizardViewModel
+    @State private var showStrengthSection = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.lg) {
+                AISectionHeader("Fine-Tune & Generate", subtitle: "Add preferences and generate your program")
+
+                // Quota display
+                if let status = viewModel.generationStatus {
+                    AIQuotaBadge(remaining: status.generationsRemaining, limit: status.generationsLimit)
+
+                    if !status.hasRemaining {
+                        Text("Resets on \(status.resetsAtFormatted)")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                } else if viewModel.isLoadingQuota {
+                    HStack(spacing: AppSpacing.xs) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Checking quota...")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                // Free-text preferences
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("Additional Preferences")
+                        .font(.headline)
+
+                    Text("Optional. Describe anything specific you want.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    TextField("e.g., focus on compounds, avoid deadlifts, more arm volume...", text: $viewModel.freeTextPreferences, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(3...5)
+
+                    HStack {
+                        Spacer()
+                        Text("\(viewModel.freeTextPreferences.count)/500")
+                            .font(.caption2)
+                            .foregroundColor(
+                                viewModel.freeTextPreferences.count > 500 ? .red : .secondary
+                            )
+                    }
+                }
+
+                Divider()
+                    .padding(.vertical, AppSpacing.xs)
+
+                // Strength data section (expandable)
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Button {
+                        withAnimation { showStrengthSection.toggle() }
+                    } label: {
+                        HStack {
+                            Text("Strength Data")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            Text("(Optional)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            Image(systemName: showStrengthSection ? "chevron.up" : "chevron.down")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+
+                    if showStrengthSection {
+                        Text("Enter your current lifts to personalize exercise selection and weights.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        if viewModel.isLoadingProfile {
+                            ProgressView("Loading saved profile...")
+                                .font(.caption)
+                        } else {
+                            ForEach($viewModel.strengthEntries) { $entry in
+                                strengthEntryRow(entry: $entry)
+                            }
+                            .onDelete { viewModel.removeStrengthEntry(at: $0) }
+
+                            if viewModel.strengthEntries.count < 20 {
+                                Button {
+                                    viewModel.addStrengthEntry()
+                                } label: {
+                                    Label("Add Exercise", systemImage: "plus.circle.fill")
+                                        .font(.subheadline)
+                                        .foregroundColor(AIColors.accent)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+    }
+
+    // MARK: - Strength Entry Row
+
+    private func strengthEntryRow(entry: Binding<StrengthDataEntry>) -> some View {
+        VStack(spacing: AppSpacing.xs) {
+            TextField("Exercise name", text: entry.exerciseName)
+                .textFieldStyle(.roundedBorder)
+
+            HStack(spacing: AppSpacing.xs) {
+                HStack(spacing: AppSpacing.xxs) {
+                    TextField("Weight", value: entry.weight, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .keyboardType(.decimalPad)
+                        .frame(width: 70)
+
+                    Picker("", selection: entry.unit) {
+                        Text("lb").tag("lb")
+                        Text("kg").tag("kg")
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 80)
+                }
+
+                HStack(spacing: AppSpacing.xxs) {
+                    TextField("Reps", value: entry.reps, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .keyboardType(.numberPad)
+                        .frame(width: 50)
+                    Text("x")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextField("Sets", value: entry.sets, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .keyboardType(.numberPad)
+                        .frame(width: 50)
+                }
+            }
+        }
+        .padding(AppSpacing.sm)
+        .cardStyle()
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AIWizardStep4PreferencesView(viewModel: AIWizardViewModel())
+    }
+    .withDependencies(.preview)
+}

--- a/Nippardation/Views/AI/AIWizardStep4PreferencesView.swift
+++ b/Nippardation/Views/AI/AIWizardStep4PreferencesView.swift
@@ -61,6 +61,53 @@ struct AIWizardStep4PreferencesView: View {
                 Divider()
                     .padding(.vertical, AppSpacing.xs)
 
+                // Template reuse section
+                VStack(alignment: .leading, spacing: AppSpacing.sm) {
+                    Toggle(isOn: $viewModel.reuseTemplates) {
+                        HStack(spacing: AppSpacing.xs) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                            Text("Reuse Existing Templates")
+                                .font(.headline)
+                        }
+                    }
+                    .tint(AIColors.accent)
+                    .onChange(of: viewModel.reuseTemplates) { _, isOn in
+                        if isOn && viewModel.availableTemplates.isEmpty {
+                            viewModel.loadTemplates()
+                        }
+                        if !isOn {
+                            viewModel.selectedTemplateIds.removeAll()
+                        }
+                    }
+
+                    if viewModel.reuseTemplates {
+                        Text("Select up to 7 templates for the AI to refresh instead of creating new ones.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        if viewModel.isLoadingTemplates {
+                            HStack(spacing: AppSpacing.xs) {
+                                ProgressView()
+                                    .controlSize(.small)
+                                Text("Loading templates...")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        } else if viewModel.availableTemplates.isEmpty {
+                            Text("No templates found.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(viewModel.availableTemplates) { template in
+                                templateReuseRow(template)
+                            }
+                        }
+                    }
+                }
+
+                Divider()
+                    .padding(.vertical, AppSpacing.xs)
+
                 // Strength data section (expandable)
                 VStack(alignment: .leading, spacing: AppSpacing.sm) {
                     Button {
@@ -110,6 +157,46 @@ struct AIWizardStep4PreferencesView: View {
             }
             .padding(AppSpacing.md)
         }
+    }
+
+    // MARK: - Template Reuse Row
+
+    private func templateReuseRow(_ template: Template) -> some View {
+        let isSelected = viewModel.selectedTemplateIds.contains(template.serverId)
+        let atMax = viewModel.selectedTemplateIds.count >= 7
+
+        return Button {
+            viewModel.toggleTemplateSelection(template.serverId)
+        } label: {
+            HStack(spacing: AppSpacing.sm) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isSelected ? AIColors.accent : .secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(template.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+
+                    Text("\(template.exerciseCount) exercises")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if template.isAiGenerated {
+                    Image(systemName: "sparkles")
+                        .font(.caption2)
+                        .foregroundColor(.purple)
+                }
+            }
+            .padding(AppSpacing.sm)
+            .cardStyle()
+        }
+        .buttonStyle(.plain)
+        .disabled(!isSelected && atMax)
+        .opacity(!isSelected && atMax ? 0.5 : 1)
     }
 
     // MARK: - Strength Entry Row

--- a/Nippardation/Views/AI/AIWizardView.swift
+++ b/Nippardation/Views/AI/AIWizardView.swift
@@ -106,6 +106,7 @@ struct AIWizardView: View {
                         GeneratedProgramPreviewView(
                             program: program,
                             metadata: viewModel.generationMetadata,
+                            reusedTemplateIds: viewModel.reusedTemplateIds,
                             onSave: {
                                 dismiss()
                             },

--- a/Nippardation/Views/AI/AIWizardView.swift
+++ b/Nippardation/Views/AI/AIWizardView.swift
@@ -1,0 +1,153 @@
+//
+//  AIWizardView.swift
+//  Nippardation
+//
+//  Multi-step wizard for AI-powered program generation
+//
+
+import SwiftUI
+
+struct AIWizardView: View {
+    @StateObject private var viewModel = AIWizardViewModel()
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var currentStep = 0
+    @State private var showPreview = false
+    private let totalSteps = 4
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                AIStepIndicator(totalSteps: totalSteps, currentStep: currentStep)
+                    .padding(.top, AppSpacing.sm)
+                    .padding(.bottom, AppSpacing.md)
+
+                Group {
+                    switch currentStep {
+                    case 0:
+                        AIWizardStep1GoalView(viewModel: viewModel)
+                    case 1:
+                        AIWizardStep2ScheduleView(viewModel: viewModel)
+                    case 2:
+                        AIWizardStep3EquipmentView(viewModel: viewModel)
+                    case 3:
+                        AIWizardStep4PreferencesView(viewModel: viewModel)
+                    default:
+                        EmptyView()
+                    }
+                }
+
+                // Navigation buttons
+                HStack(spacing: AppSpacing.md) {
+                    if currentStep > 0 {
+                        Button {
+                            withAnimation { currentStep -= 1 }
+                        } label: {
+                            Text("Back")
+                                .fontWeight(.medium)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                    }
+
+                    if currentStep < totalSteps - 1 {
+                        Button {
+                            withAnimation { currentStep += 1 }
+                        } label: {
+                            Text("Continue")
+                                .fontWeight(.semibold)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(AIColors.accent)
+                        .controlSize(.large)
+                        .disabled(!isCurrentStepValid)
+                    } else {
+                        AIGradientButton(
+                            "Generate Program",
+                            isDisabled: !viewModel.canGenerate
+                        ) {
+                            viewModel.generate()
+                        }
+                        .controlSize(.large)
+                    }
+                }
+                .padding(AppSpacing.md)
+            }
+            .navigationTitle("AI Program Generator")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .onAppear {
+                viewModel.loadQuota()
+                viewModel.loadStrengthProfile()
+            }
+            .overlay {
+                if viewModel.isGenerating {
+                    AIGeneratingView(
+                        messageIndex: viewModel.loadingMessageIndex,
+                        messages: viewModel.loadingMessages,
+                        onCancel: { viewModel.cancelGeneration() }
+                    )
+                }
+            }
+            .onChange(of: viewModel.generationComplete) { _, complete in
+                if complete {
+                    showPreview = true
+                }
+            }
+            .fullScreenCover(isPresented: $showPreview) {
+                if let program = viewModel.generatedProgram {
+                    NavigationStack {
+                        GeneratedProgramPreviewView(
+                            program: program,
+                            metadata: viewModel.generationMetadata,
+                            onSave: {
+                                dismiss()
+                            },
+                            onDiscard: {
+                                viewModel.discardGeneratedProgram()
+                                showPreview = false
+                            }
+                        )
+                    }
+                }
+            }
+            .alert("Generation Failed", isPresented: .init(
+                get: { viewModel.error != nil },
+                set: { if !$0 { viewModel.clearError() } }
+            )) {
+                if viewModel.errorIsRetryable {
+                    Button("Try Again") {
+                        viewModel.clearError()
+                        viewModel.generate()
+                    }
+                    Button("Cancel", role: .cancel) { viewModel.clearError() }
+                } else {
+                    Button("OK") { viewModel.clearError() }
+                }
+            } message: {
+                Text(viewModel.error ?? "An unknown error occurred")
+            }
+        }
+    }
+
+    private var isCurrentStepValid: Bool {
+        switch currentStep {
+        case 0: return viewModel.isStep1Valid
+        case 1: return viewModel.isStep2Valid
+        case 2: return viewModel.isStep3Valid
+        case 3: return viewModel.isStep4Valid
+        default: return false
+        }
+    }
+}
+
+#Preview {
+    AIWizardView()
+        .withDependencies(.preview)
+}

--- a/Nippardation/Views/AI/GeneratedProgramPreviewView.swift
+++ b/Nippardation/Views/AI/GeneratedProgramPreviewView.swift
@@ -1,0 +1,257 @@
+//
+//  GeneratedProgramPreviewView.swift
+//  Nippardation
+//
+//  Preview and edit screen for an AI-generated program before saving
+//
+
+import SwiftUI
+
+struct GeneratedProgramPreviewView: View {
+    @StateObject private var viewModel: GeneratedProgramPreviewViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    let onSave: () -> Void
+    let onDiscard: () -> Void
+
+    init(
+        program: Program,
+        metadata: GenerationMetadataDTO?,
+        onSave: @escaping () -> Void,
+        onDiscard: @escaping () -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: GeneratedProgramPreviewViewModel(
+            program: program,
+            metadata: metadata
+        ))
+        self.onSave = onSave
+        self.onDiscard = onDiscard
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.md) {
+                // AI header banner
+                headerBanner
+
+                // Editable program info
+                programInfoSection
+
+                // Workout list
+                ForEach(Array(viewModel.workouts.enumerated()), id: \.element.id) { workoutIndex, workout in
+                    workoutSection(workout: workout, workoutIndex: workoutIndex)
+                }
+            }
+            .padding(AppSpacing.md)
+        }
+        .navigationTitle("Review Program")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Discard") {
+                    onDiscard()
+                }
+                .foregroundColor(.red)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    viewModel.save()
+                } label: {
+                    HStack(spacing: AppSpacing.xxs) {
+                        Image(systemName: "sparkles")
+                        Text("Save")
+                    }
+                    .fontWeight(.semibold)
+                    .foregroundStyle(AIColors.gradient)
+                }
+                .disabled(viewModel.isSaving)
+            }
+        }
+        .overlay {
+            if viewModel.isSaving {
+                ProgressView("Saving...")
+                    .padding()
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: AppCornerRadius.medium))
+            }
+        }
+        .onChange(of: viewModel.savedSuccessfully) { _, saved in
+            if saved {
+                onSave()
+            }
+        }
+        .alert("Error", isPresented: .init(
+            get: { viewModel.error != nil },
+            set: { if !$0 { viewModel.clearError() } }
+        )) {
+            Button("OK") { viewModel.clearError() }
+        } message: {
+            Text(viewModel.error ?? "")
+        }
+    }
+
+    // MARK: - Header Banner
+
+    private var headerBanner: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            HStack {
+                Image(systemName: "sparkles")
+                    .font(.title3)
+                Text("AI Generated")
+                    .font(.headline)
+                Spacer()
+                if let time = viewModel.generationTimeFormatted {
+                    PillBadge(text: "Generated in \(time)", color: AIColors.accent, style: .tinted)
+                }
+            }
+            .foregroundStyle(AIColors.gradient)
+
+            HStack(spacing: AppSpacing.sm) {
+                PillBadge(
+                    text: "\(viewModel.originalProgram.daysPerWeek) days/wk",
+                    color: .blue,
+                    style: .tinted
+                )
+                PillBadge(
+                    text: "\(viewModel.totalExercises) exercises",
+                    color: .green,
+                    style: .tinted
+                )
+                if let weeks = viewModel.originalProgram.durationWeeks {
+                    PillBadge(
+                        text: "\(weeks) weeks",
+                        color: .purple,
+                        style: .tinted
+                    )
+                }
+            }
+        }
+        .padding(AppSpacing.md)
+        .aiGradientCardStyle()
+    }
+
+    // MARK: - Program Info
+
+    private var programInfoSection: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            Text("Program Details")
+                .font(.headline)
+
+            TextField("Program Name", text: $viewModel.programName)
+                .textFieldStyle(.roundedBorder)
+                .font(.body.bold())
+
+            TextField("Description (optional)", text: $viewModel.programDescription, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(2...4)
+        }
+    }
+
+    // MARK: - Workout Section
+
+    private func workoutSection(workout: GeneratedProgramPreviewViewModel.EditableWorkout, workoutIndex: Int) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            HStack {
+                Text(workout.dayLabel)
+                    .font(.headline)
+                Spacer()
+                Text("\(workout.exercises.count) exercises")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            ForEach(Array(workout.exercises.enumerated()), id: \.element.id) { exerciseIndex, exercise in
+                EditableExerciseRow(
+                    exercise: Binding(
+                        get: { viewModel.workouts[workoutIndex].exercises[exerciseIndex] },
+                        set: { viewModel.workouts[workoutIndex].exercises[exerciseIndex] = $0 }
+                    ),
+                    onDelete: {
+                        viewModel.removeExercise(workoutIndex: workoutIndex, exerciseIndex: exerciseIndex)
+                    }
+                )
+            }
+        }
+        .padding(AppSpacing.md)
+        .cardStyle()
+    }
+}
+
+// MARK: - Editable Exercise Row
+
+struct EditableExerciseRow: View {
+    @Binding var exercise: GeneratedProgramPreviewViewModel.EditableExercise
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+            HStack {
+                Text(exercise.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                Button(role: .destructive) {
+                    onDelete()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary.opacity(0.5))
+                        .font(.body)
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(spacing: AppSpacing.md) {
+                editableField("Sets", value: $exercise.workingSets)
+                editableField("Reps", text: $exercise.targetReps)
+                editableField("Rest", value: $exercise.restSeconds, suffix: "s")
+            }
+        }
+        .padding(AppSpacing.sm)
+        .background(Color(.tertiarySystemBackground))
+        .cornerRadius(AppCornerRadius.small)
+    }
+
+    private func editableField(_ label: String, value: Binding<Int>, suffix: String = "") -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            HStack(spacing: 2) {
+                TextField("", value: value, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.numberPad)
+                    .frame(width: 45)
+                    .font(.caption)
+                if !suffix.isEmpty {
+                    Text(suffix)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    private func editableField(_ label: String, text: Binding<String>) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            TextField("", text: text)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 55)
+                .font(.caption)
+        }
+    }
+}
+
+#Preview {
+    let program = AIGeneratedProgramMapper.toDomain(MockAIAPIService.sampleGenerateResponse.program)
+    NavigationStack {
+        GeneratedProgramPreviewView(
+            program: program,
+            metadata: MockAIAPIService.sampleGenerateResponse.generation,
+            onSave: {},
+            onDiscard: {}
+        )
+    }
+    .withDependencies(.preview)
+}

--- a/Nippardation/Views/AI/GeneratedProgramPreviewView.swift
+++ b/Nippardation/Views/AI/GeneratedProgramPreviewView.swift
@@ -17,12 +17,14 @@ struct GeneratedProgramPreviewView: View {
     init(
         program: Program,
         metadata: GenerationMetadataDTO?,
+        reusedTemplateIds: Set<String> = [],
         onSave: @escaping () -> Void,
         onDiscard: @escaping () -> Void
     ) {
         _viewModel = StateObject(wrappedValue: GeneratedProgramPreviewViewModel(
             program: program,
-            metadata: metadata
+            metadata: metadata,
+            reusedTemplateIds: reusedTemplateIds
         ))
         self.onSave = onSave
         self.onDiscard = onDiscard
@@ -149,10 +151,22 @@ struct GeneratedProgramPreviewView: View {
     // MARK: - Workout Section
 
     private func workoutSection(workout: GeneratedProgramPreviewViewModel.EditableWorkout, workoutIndex: Int) -> some View {
-        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+        let templateServerId = viewModel.originalProgram.workouts
+            .first { $0.serverId == workout.serverId }?.templateServerId
+
+        return VStack(alignment: .leading, spacing: AppSpacing.sm) {
             HStack {
                 Text(workout.dayLabel)
                     .font(.headline)
+
+                if !viewModel.reusedTemplateIds.isEmpty, let tid = templateServerId {
+                    if viewModel.reusedTemplateIds.contains(tid) {
+                        PillBadge(text: "Reused", color: .teal, style: .tinted)
+                    } else {
+                        PillBadge(text: "New", color: .green, style: .tinted)
+                    }
+                }
+
                 Spacer()
                 Text("\(workout.exercises.count) exercises")
                     .font(.caption)

--- a/Nippardation/Views/Exercises/ExerciseBrowserView.swift
+++ b/Nippardation/Views/Exercises/ExerciseBrowserView.swift
@@ -233,9 +233,21 @@ struct ExerciseBrowserContent: View {
         ContentUnavailableView {
             Label("No Exercises", systemImage: "figure.strengthtraining.traditional")
         } description: {
-            Text(viewModel.filter.isEmpty ? "No exercises found" : "Try adjusting your filters")
+            if let error = viewModel.error {
+                Text(error)
+            } else if viewModel.filter.isEmpty {
+                Text("No exercises found")
+            } else {
+                Text("Try adjusting your filters")
+            }
         } actions: {
-            if !viewModel.filter.isEmpty {
+            if viewModel.error != nil {
+                Button("Retry") {
+                    viewModel.clearError()
+                    viewModel.loadExercises(refresh: true)
+                }
+                .buttonStyle(.borderedProminent)
+            } else if !viewModel.filter.isEmpty {
                 Button("Clear Filters") {
                     viewModel.clearFilters()
                 }

--- a/Nippardation/Views/Programs/ProgramDeleteConfirmationView.swift
+++ b/Nippardation/Views/Programs/ProgramDeleteConfirmationView.swift
@@ -1,0 +1,181 @@
+//
+//  ProgramDeleteConfirmationView.swift
+//  Nippardation
+//
+//  Confirmation sheet for deleting an AI program with selective template cleanup
+//
+
+import SwiftUI
+
+struct ProgramDeleteConfirmationView: View {
+    let program: Program
+    var isDeletingProgram: Bool = false
+    let onConfirmDelete: ([String]) -> Void
+    let onCancel: () -> Void
+
+    @State private var keepTemplateIds: Set<String> = []
+
+    /// Unique templates from the program's workouts (deduplicated by server ID).
+    /// The backend handles safety — only AI-generated templates not used elsewhere get deleted.
+    private var aiTemplates: [(serverId: String, name: String, exerciseCount: Int)] {
+        var seen = Set<String>()
+        var result: [(serverId: String, name: String, exerciseCount: Int)] = []
+
+        for workout in program.workouts {
+            guard let template = workout.template,
+                  !seen.contains(workout.templateServerId) else { continue }
+            seen.insert(workout.templateServerId)
+            result.append((
+                serverId: workout.templateServerId,
+                name: template.name,
+                exerciseCount: template.exerciseCount
+            ))
+        }
+
+        return result.sorted { $0.name < $1.name }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: AppSpacing.lg) {
+                        // Header
+                        VStack(spacing: AppSpacing.xs) {
+                            Image(systemName: "trash.circle.fill")
+                                .font(.system(size: 48))
+                                .foregroundColor(.red)
+
+                            Text("Delete \(program.name)?")
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .multilineTextAlignment(.center)
+
+                            Text("This program has \(aiTemplates.count) AI-generated template\(aiTemplates.count == 1 ? "" : "s"). Select any you'd like to keep.")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding(.top, AppSpacing.md)
+
+                        // Template list
+                        VStack(spacing: AppSpacing.xs) {
+                            ForEach(aiTemplates, id: \.serverId) { template in
+                                templateRow(template)
+                            }
+                        }
+
+                        // Convenience buttons
+                        HStack(spacing: AppSpacing.sm) {
+                            Button {
+                                keepTemplateIds = []
+                            } label: {
+                                Text("Delete All Templates")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                            }
+                            .buttonStyle(.bordered)
+                            .tint(.red)
+                            .disabled(keepTemplateIds.isEmpty)
+
+                            Button {
+                                keepTemplateIds = Set(aiTemplates.map(\.serverId))
+                            } label: {
+                                Text("Keep All Templates")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(keepTemplateIds.count == aiTemplates.count)
+                        }
+                    }
+                    .padding(AppSpacing.md)
+                }
+
+                // Bottom action area
+                VStack(spacing: AppSpacing.sm) {
+                    Divider()
+
+                    VStack(spacing: AppSpacing.xs) {
+                        if !keepTemplateIds.isEmpty {
+                            Text("Keeping \(keepTemplateIds.count) template\(keepTemplateIds.count == 1 ? "" : "s"), deleting \(aiTemplates.count - keepTemplateIds.count)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text("Deleting program and all \(aiTemplates.count) template\(aiTemplates.count == 1 ? "" : "s")")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
+
+                        Button(role: .destructive) {
+                            onConfirmDelete(Array(keepTemplateIds))
+                        } label: {
+                            if isDeletingProgram {
+                                ProgressView()
+                                    .frame(maxWidth: .infinity)
+                            } else {
+                                Text("Delete Program")
+                                    .fontWeight(.semibold)
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.red)
+                        .controlSize(.large)
+                        .disabled(isDeletingProgram)
+                    }
+                    .padding(.horizontal, AppSpacing.md)
+                    .padding(.bottom, AppSpacing.md)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        onCancel()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Template Row
+
+    private func templateRow(_ template: (serverId: String, name: String, exerciseCount: Int)) -> some View {
+        let isKept = keepTemplateIds.contains(template.serverId)
+
+        return Button {
+            if isKept {
+                keepTemplateIds.remove(template.serverId)
+            } else {
+                keepTemplateIds.insert(template.serverId)
+            }
+        } label: {
+            HStack(spacing: AppSpacing.sm) {
+                Image(systemName: isKept ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isKept ? .green : .secondary)
+                    .font(.title3)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(template.name)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+
+                    Text("\(template.exerciseCount) exercises")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Text(isKept ? "Keep" : "Delete")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(isKept ? .green : .red)
+            }
+            .padding(AppSpacing.sm)
+            .cardStyle()
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Nippardation/Views/Programs/ProgramEmptyStateView.swift
+++ b/Nippardation/Views/Programs/ProgramEmptyStateView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ProgramEmptyStateView: View {
     let onCreate: () -> Void
+    var onGenerateWithAI: (() -> Void)?
 
     var body: some View {
         VStack(spacing: AppSpacing.lg) {
@@ -39,17 +40,26 @@ struct ProgramEmptyStateView: View {
             }
 
             // CTA
-            Button(action: onCreate) {
-                HStack {
-                    Image(systemName: "plus.circle.fill")
-                    Text("Create Program")
+            VStack(spacing: AppSpacing.sm) {
+                if let onGenerateWithAI {
+                    AIGradientButton("Generate with AI") {
+                        onGenerateWithAI()
+                    }
+                    .padding(.horizontal, AppSpacing.xl)
                 }
-                .fontWeight(.semibold)
-                .frame(maxWidth: .infinity)
+
+                Button(action: onCreate) {
+                    HStack {
+                        Image(systemName: "plus.circle.fill")
+                        Text("Create Manually")
+                    }
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.horizontal, AppSpacing.xl)
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .padding(.horizontal, AppSpacing.xl)
 
             Spacer()
         }

--- a/Nippardation/Views/Programs/ProgramListView.swift
+++ b/Nippardation/Views/Programs/ProgramListView.swift
@@ -12,7 +12,6 @@ struct ProgramListView: View {
     @StateObject private var viewModel = ProgramListViewModel()
     @State private var showCreateProgram = false
     @State private var showAIWizard = false
-    @State private var showCreateChoice = false
     @State private var programToDelete: Program?
     @State private var showDeleteConfirmation = false
     @State private var showShareSheet = false
@@ -21,30 +20,6 @@ struct ProgramListView: View {
     var body: some View {
         content
             .navigationTitle("My Programs")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showCreateChoice = true
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                }
-            }
-            .confirmationDialog("Create Program", isPresented: $showCreateChoice) {
-                Button {
-                    showCreateProgram = true
-                } label: {
-                    Label("Create Manually", systemImage: "square.and.pencil")
-                }
-
-                Button {
-                    showAIWizard = true
-                } label: {
-                    Label("Generate with AI", systemImage: "sparkles")
-                }
-            } message: {
-                Text("How would you like to create your program?")
-            }
             .sheet(isPresented: $showCreateProgram) {
                 NavigationStack {
                     ProgramWizardView()
@@ -140,79 +115,125 @@ struct ProgramListView: View {
     }
 
     private var programList: some View {
-        ScrollView {
-            LazyVStack(spacing: AppSpacing.md) {
-                ForEach(viewModel.programs) { program in
-                    VStack(alignment: .leading, spacing: AppSpacing.xs) {
-                        NavigationLink(destination: ProgramDetailView(programServerId: program.serverId)) {
-                            ProgramLibraryCard(program: program)
-                        }
-                        .buttonStyle(.plain)
-                        .contextMenu {
-                            if !program.isActive {
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                LazyVStack(spacing: AppSpacing.md) {
+                    ForEach(viewModel.programs) { program in
+                        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                            NavigationLink(destination: ProgramDetailView(programServerId: program.serverId)) {
+                                ProgramLibraryCard(program: program)
+                            }
+                            .buttonStyle(.plain)
+                            .contextMenu {
+                                if !program.isActive {
+                                    Button {
+                                        viewModel.activateProgram(program)
+                                    } label: {
+                                        Label("Activate", systemImage: "checkmark.circle")
+                                    }
+                                }
+
                                 Button {
-                                    viewModel.activateProgram(program)
+                                    viewModel.duplicateProgram(program)
                                 } label: {
-                                    Label("Activate", systemImage: "checkmark.circle")
+                                    Label("Duplicate", systemImage: "doc.on.doc")
+                                }
+
+                                Button {
+                                    shareViewModel.createShare(type: "program", itemId: program.serverId)
+                                } label: {
+                                    Label("Share", systemImage: "square.and.arrow.up")
+                                }
+
+                                Divider()
+
+                                Button(role: .destructive) {
+                                    programToDelete = program
+                                    showDeleteConfirmation = true
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
                                 }
                             }
 
-                            Button {
-                                viewModel.duplicateProgram(program)
-                            } label: {
-                                Label("Duplicate", systemImage: "doc.on.doc")
-                            }
-
-                            Button {
-                                shareViewModel.createShare(type: "program", itemId: program.serverId)
-                            } label: {
-                                Label("Share", systemImage: "square.and.arrow.up")
-                            }
-
-                            Divider()
-
-                            Button(role: .destructive) {
-                                programToDelete = program
-                                showDeleteConfirmation = true
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                        }
-
-                        if program.isActive {
-                            Label("Current Active Program", systemImage: "checkmark.circle.fill")
-                                .font(.caption)
-                                .foregroundColor(.green)
-                                .padding(.horizontal, AppSpacing.xs)
-                        } else {
-                            Button {
-                                viewModel.activateProgram(program)
-                            } label: {
-                                Label("Set As Active", systemImage: "checkmark.circle")
+                            if program.isActive {
+                                Label("Current Active Program", systemImage: "checkmark.circle.fill")
                                     .font(.caption)
-                                    .fontWeight(.semibold)
-                                    .frame(maxWidth: .infinity)
+                                    .foregroundColor(.green)
+                                    .padding(.horizontal, AppSpacing.xs)
+                            } else {
+                                Button {
+                                    viewModel.activateProgram(program)
+                                } label: {
+                                    Label("Set As Active", systemImage: "checkmark.circle")
+                                        .font(.caption)
+                                        .fontWeight(.semibold)
+                                        .frame(maxWidth: .infinity)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
                             }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
+                        }
+                    }
+
+                    if viewModel.hasMore {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                            Spacer()
+                        }
+                        .padding(.vertical, AppSpacing.md)
+                        .onAppear {
+                            viewModel.loadMore()
                         }
                     }
                 }
-
-                if viewModel.hasMore {
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                        Spacer()
-                    }
-                    .padding(.vertical, AppSpacing.md)
-                    .onAppear {
-                        viewModel.loadMore()
-                    }
-                }
+                .padding(AppSpacing.md)
+                // Extra bottom padding so content isn't hidden behind the pinned buttons
+                .padding(.bottom, 100)
             }
-            .padding(AppSpacing.md)
+
+            pinnedBottomButtons
         }
+    }
+
+    private var pinnedBottomButtons: some View {
+        VStack(spacing: AppSpacing.sm) {
+            AIGradientButton("Generate with AI") {
+                showAIWizard = true
+            }
+
+            Button {
+                showCreateProgram = true
+            } label: {
+                HStack(spacing: AppSpacing.xs) {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Create Manually")
+                }
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(.horizontal, AppSpacing.md)
+        .padding(.top, AppSpacing.md)
+        .padding(.bottom, AppSpacing.lg)
+        .background(
+            .ultraThinMaterial,
+            in: Rectangle()
+        )
+        .mask(
+            VStack(spacing: 0) {
+                LinearGradient(
+                    colors: [.clear, .black],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 16)
+
+                Color.black
+            }
+        )
     }
 }
 

--- a/Nippardation/Views/Programs/ProgramListView.swift
+++ b/Nippardation/Views/Programs/ProgramListView.swift
@@ -12,8 +12,6 @@ struct ProgramListView: View {
     @StateObject private var viewModel = ProgramListViewModel()
     @State private var showCreateProgram = false
     @State private var showAIWizard = false
-    @State private var programToDelete: Program?
-    @State private var showDeleteConfirmation = false
     @State private var showShareSheet = false
     @StateObject private var shareViewModel = ShareViewModel()
 
@@ -38,18 +36,34 @@ struct ProgramListView: View {
                     viewModel.loadPrograms(refresh: true)
                 }
             }
-            .alert("Delete Program", isPresented: $showDeleteConfirmation) {
+            .alert("Delete Program", isPresented: $viewModel.showSimpleDeleteAlert) {
                 Button("Cancel", role: .cancel) {
-                    programToDelete = nil
+                    viewModel.clearDeleteState()
                 }
                 Button("Delete", role: .destructive) {
-                    if let program = programToDelete {
+                    if let program = viewModel.programToDelete {
                         viewModel.deleteProgram(program)
                     }
-                    programToDelete = nil
+                    viewModel.clearDeleteState()
                 }
             } message: {
                 Text("Are you sure you want to delete this program? This cannot be undone.")
+            }
+            .sheet(isPresented: $viewModel.showTemplateDeleteSheet) {
+                if let detail = viewModel.programToDeleteDetail {
+                    ProgramDeleteConfirmationView(
+                        program: detail,
+                        isDeletingProgram: viewModel.isDeletingProgram,
+                        onConfirmDelete: { keepIds in
+                            viewModel.deleteProgramWithTemplates(keepTemplateIds: keepIds)
+                            // Sheet dismisses when ViewModel sets showTemplateDeleteSheet = false
+                            // AFTER the deletion (including cache cleanup) completes.
+                        },
+                        onCancel: {
+                            viewModel.clearDeleteState()
+                        }
+                    )
+                }
             }
             .sheet(isPresented: $showShareSheet) {
                 if let url = shareViewModel.shareURL {
@@ -75,6 +89,17 @@ struct ProgramListView: View {
             .onAppear {
                 if viewModel.programs.isEmpty {
                     viewModel.loadPrograms()
+                }
+            }
+            .overlay {
+                if viewModel.isFetchingDeleteDetail {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                        .overlay {
+                            ProgressView()
+                                .padding()
+                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: AppCornerRadius.medium))
+                        }
                 }
             }
             .alert("Error", isPresented: .init(
@@ -148,8 +173,7 @@ struct ProgramListView: View {
                                 Divider()
 
                                 Button(role: .destructive) {
-                                    programToDelete = program
-                                    showDeleteConfirmation = true
+                                    viewModel.prepareDeleteProgram(program)
                                 } label: {
                                     Label("Delete", systemImage: "trash")
                                 }

--- a/Nippardation/Views/Programs/ProgramListView.swift
+++ b/Nippardation/Views/Programs/ProgramListView.swift
@@ -11,6 +11,8 @@ struct ProgramListView: View {
 
     @StateObject private var viewModel = ProgramListViewModel()
     @State private var showCreateProgram = false
+    @State private var showAIWizard = false
+    @State private var showCreateChoice = false
     @State private var programToDelete: Program?
     @State private var showDeleteConfirmation = false
     @State private var showShareSheet = false
@@ -22,19 +24,41 @@ struct ProgramListView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
-                        showCreateProgram = true
+                        showCreateChoice = true
                     } label: {
                         Image(systemName: "plus")
                     }
                 }
+            }
+            .confirmationDialog("Create Program", isPresented: $showCreateChoice) {
+                Button {
+                    showCreateProgram = true
+                } label: {
+                    Label("Create Manually", systemImage: "square.and.pencil")
+                }
+
+                Button {
+                    showAIWizard = true
+                } label: {
+                    Label("Generate with AI", systemImage: "sparkles")
+                }
+            } message: {
+                Text("How would you like to create your program?")
             }
             .sheet(isPresented: $showCreateProgram) {
                 NavigationStack {
                     ProgramWizardView()
                 }
             }
+            .fullScreenCover(isPresented: $showAIWizard) {
+                AIWizardView()
+            }
             .onChange(of: showCreateProgram) { oldValue, newValue in
-                // Refresh list after create sheet closes so newly created programs appear immediately.
+                if oldValue && !newValue {
+                    viewModel.loadPrograms(refresh: true)
+                }
+            }
+            .onChange(of: showAIWizard) { oldValue, newValue in
                 if oldValue && !newValue {
                     viewModel.loadPrograms(refresh: true)
                 }
@@ -95,7 +119,10 @@ struct ProgramListView: View {
         if viewModel.isLoading && viewModel.programs.isEmpty {
             loadingView
         } else if viewModel.programs.isEmpty {
-            ProgramEmptyStateView(onCreate: { showCreateProgram = true })
+            ProgramEmptyStateView(
+                onCreate: { showCreateProgram = true },
+                onGenerateWithAI: { showAIWizard = true }
+            )
         } else {
             programList
         }

--- a/Nippardation/Views/Templates/TemplateEditorView.swift
+++ b/Nippardation/Views/Templates/TemplateEditorView.swift
@@ -127,11 +127,8 @@ struct TemplateEditorView: View {
         }
         .onChange(of: viewModel.savedTemplate) { _, newValue in
             if let template = newValue {
-                if let onSave {
-                    onSave(template)
-                } else {
-                    dismiss()
-                }
+                onSave?(template)
+                dismiss()
             }
         }
         .disabled(viewModel.isSaving)

--- a/Nippardation/Views/Templates/TemplateListView.swift
+++ b/Nippardation/Views/Templates/TemplateListView.swift
@@ -78,6 +78,8 @@ struct TemplateListView: View {
             .onAppear {
                 if viewModel.templates.isEmpty {
                     viewModel.loadTemplates()
+                } else {
+                    viewModel.loadIfStale()
                 }
             }
             .alert("Error", isPresented: .init(

--- a/Nippardation/Views/Templates/TemplateListView.swift
+++ b/Nippardation/Views/Templates/TemplateListView.swift
@@ -35,13 +35,10 @@ struct TemplateListView: View {
             }
             .sheet(isPresented: $showCreateTemplate) {
                 NavigationStack {
-                    TemplateEditorView()
-                }
-            }
-            .onChange(of: showCreateTemplate) { oldValue, newValue in
-                // Refresh list after create sheet closes so newly created templates appear immediately.
-                if oldValue && !newValue {
-                    viewModel.loadTemplates(refresh: true)
+                    TemplateEditorView(onSave: { template in
+                        viewModel.handleTemplateSaved(template)
+                        showCreateTemplate = false
+                    })
                 }
             }
             .alert("Delete Template", isPresented: $showDeleteConfirmation) {
@@ -129,7 +126,12 @@ struct TemplateListView: View {
                     NewTemplateCard(onTap: { showCreateTemplate = true })
 
                     ForEach(viewModel.filteredTemplates) { template in
-                        NavigationLink(destination: TemplateEditorView(existingTemplate: template)) {
+                        NavigationLink(destination: TemplateEditorView(
+                            existingTemplate: template,
+                            onSave: { saved in
+                                viewModel.handleTemplateSaved(saved)
+                            }
+                        )) {
                             TemplateGridCard(template: template)
                         }
                         .buttonStyle(.plain)

--- a/NippardationTests/API/AIAPIServiceTests.swift
+++ b/NippardationTests/API/AIAPIServiceTests.swift
@@ -1,0 +1,307 @@
+//
+//  AIAPIServiceTests.swift
+//  NippardationTests
+//
+//  Tests for AIAPIService
+//
+
+import Testing
+import Foundation
+@testable import Nippardation
+
+@Suite(.serialized)
+struct AIAPIServiceTests {
+
+    private func createService(authProvider: AuthTokenProviding = MockAuthTokenProvider()) -> (AIAPIService, String) {
+        let sessionID = MockURLProtocol.makeSessionID()
+        MockURLProtocol.reset(sessionID: sessionID)
+        return (AIAPIService(session: MockURLProtocol.mockSession(sessionID: sessionID), authProvider: authProvider), sessionID)
+    }
+
+    // MARK: - generateProgram Tests
+
+    @Test func generateProgramBuildsCorrectRequest() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            #expect(request.url?.path.contains("api/ai/generate-program") == true)
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                #expect(json["inspirationSource"] as? String == "Push Pull Legs")
+                #expect(json["daysPerWeek"] as? Int == 4)
+                #expect(json["sessionDurationMinutes"] as? Int == 60)
+                #expect(json["experienceLevel"] as? String == "intermediate")
+                #expect(json["goal"] as? String == "hypertrophy")
+                #expect((json["equipment"] as? [String])?.count == 3)
+                #expect(json["useTrainingHistory"] as? Bool == false)
+            }
+
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 401)
+        }
+
+        let request = GenerateProgramRequest(
+            inspirationSource: "Push Pull Legs",
+            daysPerWeek: 4,
+            sessionDurationMinutes: 60,
+            experienceLevel: "intermediate",
+            goal: "hypertrophy",
+            equipment: ["barbell", "dumbbell", "cable"],
+            useTrainingHistory: false,
+            manualStrengthData: nil,
+            freeTextPreferences: nil
+        )
+
+        do {
+            _ = try await service.generateProgram(request)
+        } catch {
+            // Expected — we returned 401
+        }
+    }
+
+    @Test func generateProgramDecodesResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let json: [String: Any] = [
+                "success": true,
+                "data": [
+                    "program": [
+                        "id": "ai_prog_001",
+                        "name": "AI Hypertrophy Program",
+                        "description": "A 4-day program",
+                        "daysPerWeek": 4,
+                        "durationWeeks": 8,
+                        "workouts": [] as [[String: Any]],
+                        "isAiGenerated": true,
+                        "createdAt": "2026-03-23T00:00:00Z",
+                        "updatedAt": "2026-03-23T00:00:00Z"
+                    ] as [String: Any],
+                    "generation": [
+                        "timeMs": 15000,
+                        "model": "claude-sonnet-4-5-20250514",
+                        "personalizationApplied": true
+                    ] as [String: Any]
+                ] as [String: Any],
+                "correlationId": "req_test_123"
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let request = GenerateProgramRequest(
+            inspirationSource: "PPL",
+            daysPerWeek: 4,
+            sessionDurationMinutes: 60,
+            experienceLevel: "intermediate",
+            goal: "hypertrophy",
+            equipment: ["barbell"],
+            useTrainingHistory: false,
+            manualStrengthData: nil,
+            freeTextPreferences: nil
+        )
+
+        let result = try await service.generateProgram(request)
+        #expect(result.program.id == "ai_prog_001")
+        #expect(result.program.name == "AI Hypertrophy Program")
+        #expect(result.program.isAiGenerated == true)
+        #expect(result.generation.timeMs == 15000)
+        #expect(result.generation.model == "claude-sonnet-4-5-20250514")
+    }
+
+    @Test func generateProgramRequiresAuth() async throws {
+        let (service, sessionID) = createService(authProvider: MockAuthTokenProvider(token: nil))
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 200)
+        }
+
+        let request = GenerateProgramRequest(
+            inspirationSource: "PPL",
+            daysPerWeek: 4,
+            sessionDurationMinutes: 60,
+            experienceLevel: "intermediate",
+            goal: "hypertrophy",
+            equipment: ["barbell"],
+            useTrainingHistory: false,
+            manualStrengthData: nil,
+            freeTextPreferences: nil
+        )
+
+        do {
+            _ = try await service.generateProgram(request)
+            Issue.record("Expected unauthorized error")
+        } catch let error as RepositoryError {
+            if case .unauthorized = error {
+                // Expected
+            } else {
+                Issue.record("Expected unauthorized, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - fetchGenerationStatus Tests
+
+    @Test func fetchGenerationStatusBuildsCorrectRequest() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            #expect(request.url?.path.contains("api/ai/generation-status") == true)
+            #expect(request.httpMethod == "GET")
+            return MockURLProtocol.errorResponse(for: request.url!, statusCode: 401)
+        }
+
+        do {
+            _ = try await service.fetchGenerationStatus()
+        } catch {
+            // Expected
+        }
+    }
+
+    @Test func fetchGenerationStatusDecodesResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let json: [String: Any] = [
+                "generationsUsed": 1,
+                "generationsLimit": 3,
+                "generationsRemaining": 2,
+                "resetsAt": "2026-04-01T00:00:00.000Z",
+                "tier": "free"
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let result = try await service.fetchGenerationStatus()
+        #expect(result.generationsUsed == 1)
+        #expect(result.generationsLimit == 3)
+        #expect(result.generationsRemaining == 2)
+        #expect(result.tier == "free")
+    }
+
+    // MARK: - Strength Profile Tests
+
+    @Test func saveStrengthProfileBuildsCorrectRequest() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            #expect(request.url?.path.contains("api/ai/strength-profile") == true)
+            #expect(request.httpMethod == "PUT")
+
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+               let entries = json["entries"] as? [[String: Any]] {
+                #expect(entries.count == 1)
+                #expect(entries[0]["exerciseName"] as? String == "Squat")
+                #expect(entries[0]["weight"] as? Double == 225)
+            }
+
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, nil)
+        }
+
+        let request = StrengthProfileRequest(entries: [
+            StrengthDataEntry(exerciseName: "Squat", weight: 225, unit: "lb", reps: 5, sets: 3)
+        ])
+
+        try await service.saveStrengthProfile(request)
+    }
+
+    @Test func fetchStrengthProfileDecodesResponse() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            #expect(request.url?.path.contains("api/ai/strength-profile") == true)
+            #expect(request.httpMethod == "GET")
+
+            let json: [String: Any] = [
+                "entries": [
+                    [
+                        "exerciseName": "Bench Press",
+                        "weight": 185,
+                        "unit": "lb",
+                        "reps": 8,
+                        "sets": 3,
+                        "matchedExerciseId": "ex_bench"
+                    ] as [String: Any]
+                ]
+            ]
+            let data = try! JSONSerialization.data(withJSONObject: json)
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let result = try await service.fetchStrengthProfile()
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].exerciseName == "Bench Press")
+        #expect(result.entries[0].weight == 185)
+        #expect(result.entries[0].matchedExerciseId == "ex_bench")
+    }
+
+    // MARK: - Error Handling Tests
+
+    @Test func handlesRateLimiting() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 429,
+                httpVersion: nil,
+                headerFields: ["Retry-After": "60"]
+            )!
+            return (response, nil)
+        }
+
+        do {
+            _ = try await service.fetchGenerationStatus()
+            Issue.record("Expected rateLimited error")
+        } catch let error as RepositoryError {
+            if case .rateLimited(let retryAfter) = error {
+                #expect(retryAfter == 60)
+            } else {
+                Issue.record("Expected rateLimited, got \(error)")
+            }
+        }
+    }
+
+    @Test func handles422Validation() async throws {
+        let (service, sessionID) = createService()
+
+        MockURLProtocol.setRequestHandler(for: sessionID) { request in
+            return MockURLProtocol.errorResponse(
+                for: request.url!,
+                statusCode: 422,
+                message: "daysPerWeek must be between 1 and 7"
+            )
+        }
+
+        let request = GenerateProgramRequest(
+            inspirationSource: "PPL",
+            daysPerWeek: 10,
+            sessionDurationMinutes: 60,
+            experienceLevel: "intermediate",
+            goal: "hypertrophy",
+            equipment: ["barbell"],
+            useTrainingHistory: false,
+            manualStrengthData: nil,
+            freeTextPreferences: nil
+        )
+
+        do {
+            _ = try await service.generateProgram(request)
+            Issue.record("Expected validation error")
+        } catch let error as RepositoryError {
+            if case .validationError = error {
+                // Expected
+            } else {
+                Issue.record("Expected validationError, got \(error)")
+            }
+        }
+    }
+}

--- a/NippardationTests/API/AIAPIServiceTests.swift
+++ b/NippardationTests/API/AIAPIServiceTests.swift
@@ -51,7 +51,8 @@ struct AIAPIServiceTests {
             equipment: ["barbell", "dumbbell", "cable"],
             useTrainingHistory: false,
             manualStrengthData: nil,
-            freeTextPreferences: nil
+            freeTextPreferences: nil,
+            reuseTemplateIds: nil
         )
 
         do {
@@ -101,7 +102,8 @@ struct AIAPIServiceTests {
             equipment: ["barbell"],
             useTrainingHistory: false,
             manualStrengthData: nil,
-            freeTextPreferences: nil
+            freeTextPreferences: nil,
+            reuseTemplateIds: nil
         )
 
         let result = try await service.generateProgram(request)
@@ -128,7 +130,8 @@ struct AIAPIServiceTests {
             equipment: ["barbell"],
             useTrainingHistory: false,
             manualStrengthData: nil,
-            freeTextPreferences: nil
+            freeTextPreferences: nil,
+            reuseTemplateIds: nil
         )
 
         do {
@@ -290,7 +293,8 @@ struct AIAPIServiceTests {
             equipment: ["barbell"],
             useTrainingHistory: false,
             manualStrengthData: nil,
-            freeTextPreferences: nil
+            freeTextPreferences: nil,
+            reuseTemplateIds: nil
         )
 
         do {

--- a/NippardationTests/Helpers/MockAPIServices.swift
+++ b/NippardationTests/Helpers/MockAPIServices.swift
@@ -288,6 +288,12 @@ actor MockProgramAPIService: ProgramAPIServiceProtocol {
         programs.removeAll { $0.id == id }
     }
 
+    func deleteProgram(id: String, deleteTemplates: Bool, keepTemplateIds: [String]) async throws -> Int {
+        if shouldFail { throw failureError }
+        programs.removeAll { $0.id == id }
+        return deleteTemplates ? 3 : 0
+    }
+
     func activateProgram(id: String) async throws -> ProgramDTO {
         if shouldFail { throw failureError }
 


### PR DESCRIPTION
## Summary

- **Selective template cleanup on program delete**: Deleting an AI-generated program now shows a confirmation sheet where users choose which templates to keep vs. delete alongside the program. Non-AI programs use the existing simple delete alert.
- **Template reuse in AI generation**: AI wizard step 4 adds a "Reuse Existing Templates" toggle. Users can select up to 7 templates for the AI to refresh instead of creating new ones. Preview shows "Reused" / "New" badges per workout.
- **Pinned bottom buttons**: Programs screen now has Generate with AI and Create Manually buttons pinned at the bottom with a blur backdrop.
- **Template cache fixes**: AI-generated templates are cached locally after generation so they appear on the Templates screen immediately. Template list also detects deletions without manual refresh.
- **Template exercise count fix**: List refreshes no longer destroy cached exercise data, fixing exercise counts resetting to 0.

## Test plan

- [ ] Delete a non-AI program → simple confirmation alert (unchanged behavior)
- [ ] Delete an AI program → template selection sheet appears with all templates listed
- [ ] Select templates to keep, confirm delete → program and unkept templates removed from both server and local cache
- [ ] Navigate to Templates tab → deleted templates are gone without manual refresh
- [ ] AI wizard → toggle "Reuse Existing Templates" ON → templates load, select up to 7
- [ ] Generate with reuse → preview shows "Reused" / "New" badges on workout sections
- [ ] Generate without reuse → works as before, no badges shown
- [ ] After AI generation, navigate to Templates tab → new templates appear immediately