### PR TITLE
Remove hardcoded workout templates and add first-launch guidance

### DIFF
--- a/Nippardation/Exercise/WorkoutSelectionView.swift
+++ b/Nippardation/Exercise/WorkoutSelectionView.swift
@@ -59,27 +59,6 @@ struct WorkoutSelectionView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-
-                Section("Quick Start Workouts") {
-                    ForEach(fallbackWorkouts, id: \.self) { workout in
-                        Button {
-                            startWorkout(template: workout)
-                        } label: {
-                            HStack {
-                                Text(workout.name)
-                                    .foregroundStyle(colorScheme == .dark ? Color.white : Color.appTheme)
-                                Spacer()
-                                Image(systemName: "play.circle.fill")
-                                    .resizable()
-                                    .frame(width: 32, height: 32)
-                                    .aspectRatio(contentMode: .fit)
-                            }
-                            .contentShape(Rectangle())
-                        }
-                        .tint(Color.appTheme)
-                        .buttonStyle(.automatic)
-                    }
-                }
             }
             .listStyle(.insetGrouped)
         }
@@ -97,10 +76,6 @@ struct WorkoutSelectionView: View {
         }
     }
 
-    private var fallbackWorkouts: [Workout] {
-        [upperStrength, lowerStrength, pullDay, pushDay, legDay]
-    }
-    
     private func startWorkout(template: Workout) {
         let trackedWorkout = workoutManager.startWorkout(template: template)
         onWorkoutSelected(trackedWorkout)

--- a/Nippardation/Home/HomeView.swift
+++ b/Nippardation/Home/HomeView.swift
@@ -15,9 +15,20 @@ struct HomeView: View {
 
     @State private var startNewWorkout: Bool = false
     @State private var showActiveWorkout: Bool = false
+    @State private var showNoProgramsModal: Bool = false
+    @State private var showCreateProgram: Bool = false
+    @State private var showAIWizard: Bool = false
+    @State private var pendingModalAction: PostModalAction?
 
     // Add state to track if we've done initial loading
     @State private var didCheckForActiveWorkout: Bool = false
+
+    private enum PostModalAction {
+        case createManually
+        case generateWithAI
+        case browsePrograms
+        case startFromTemplate
+    }
 
     var body: some View {
         ZStack {
@@ -91,7 +102,11 @@ struct HomeView: View {
                         }
                     } else {
                         Button {
-                            startNewWorkout = true
+                            if viewModel.hasAnyPrograms == true {
+                                startNewWorkout = true
+                            } else {
+                                showNoProgramsModal = true
+                            }
                         } label: {
                             HStack {
                                 Image(systemName: "play.circle")
@@ -127,11 +142,57 @@ struct HomeView: View {
                     Color.clear.onAppear { showActiveWorkout = false }
                 }
             }
+            .sheet(isPresented: $showNoProgramsModal, onDismiss: {
+                switch pendingModalAction {
+                case .generateWithAI:
+                    showAIWizard = true
+                case .createManually:
+                    showCreateProgram = true
+                case .browsePrograms:
+                    selectedTab = .programs
+                case .startFromTemplate:
+                    showActiveWorkout = true
+                case nil:
+                    break
+                }
+                pendingModalAction = nil
+            }) {
+                NoProgramsModalView(
+                    templates: viewModel.userTemplates,
+                    onCreateManually: {
+                        pendingModalAction = .createManually
+                        showNoProgramsModal = false
+                    },
+                    onGenerateWithAI: {
+                        pendingModalAction = .generateWithAI
+                        showNoProgramsModal = false
+                    },
+                    onBrowsePrograms: {
+                        pendingModalAction = .browsePrograms
+                        showNoProgramsModal = false
+                    },
+                    onSelectTemplate: { template in
+                        startWorkoutFromTemplate(template)
+                        pendingModalAction = .startFromTemplate
+                        showNoProgramsModal = false
+                    }
+                )
+                .presentationDetents(viewModel.userTemplates.isEmpty ? [.medium] : [.medium, .large])
+            }
+            .sheet(isPresented: $showCreateProgram) {
+                NavigationStack {
+                    ProgramWizardView()
+                }
+            }
+            .fullScreenCover(isPresented: $showAIWizard) {
+                AIWizardView()
+            }
         }
         .navigationTitle("Home")
         .onAppear {
             workoutManager.loadCompletedWorkouts()
             viewModel.loadDashboard()
+            viewModel.checkForPrograms()
             viewModel.computeWeeklyStats(from: workoutManager.completedWorkouts)
 
             if !didCheckForActiveWorkout {
@@ -139,9 +200,56 @@ struct HomeView: View {
                 didCheckForActiveWorkout = true
             }
         }
+        .onChange(of: showCreateProgram) { oldValue, newValue in
+            if oldValue && !newValue {
+                viewModel.checkForPrograms()
+            }
+        }
+        .onChange(of: showAIWizard) { oldValue, newValue in
+            if oldValue && !newValue {
+                viewModel.checkForPrograms()
+            }
+        }
         .onChange(of: workoutManager.completedWorkouts.count) {
             viewModel.computeWeeklyStats(from: workoutManager.completedWorkouts)
         }
+    }
+
+    // MARK: - Template → Workout
+
+    private func startWorkoutFromTemplate(_ template: Template) {
+        let exercises = template.exercises
+            .sorted(by: { $0.orderIndex < $1.orderIndex })
+            .map { templateExercise in
+                let libraryItem = templateExercise.exerciseLibraryItem
+                let exerciseName = libraryItem?.name ?? "Exercise"
+                let muscles = libraryItem?.primaryMuscles ?? []
+                let restSeconds = max(30, templateExercise.restSeconds ?? 90)
+                let restMinutes = max(1, Int(round(Double(restSeconds) / 60.0)))
+
+                return Exercise(
+                    type: ExerciseType(name: exerciseName, muscleGroup: muscles),
+                    example: libraryItem?.videoUrl?.absoluteString ?? "",
+                    lastSetIntensityTechnique: templateExercise.notes ?? "Failure",
+                    warmUpSets: templateExercise.warmupSets ?? 0,
+                    workingSets: max(1, templateExercise.workingSets),
+                    reps: parseRepsRange(from: templateExercise.targetReps),
+                    rest: restMinutes...restMinutes
+                )
+            }
+
+        let workoutName = template.name.isEmpty ? "Workout" : template.name
+        let workout = Workout(name: workoutName, exercises: exercises)
+        _ = workoutManager.startWorkout(template: workout)
+    }
+
+    private func parseRepsRange(from targetReps: String?) -> ClosedRange<Int> {
+        guard let targetReps, !targetReps.isEmpty else { return 8...12 }
+        let values = targetReps.split(whereSeparator: { !$0.isNumber }).compactMap { Int($0) }
+        guard let first = values.first else { return 8...12 }
+        let lower = max(1, first)
+        let upper = values.count > 1 ? max(lower, values[1]) : lower
+        return lower...upper
     }
 
     // MARK: - Hero Section

--- a/Nippardation/Home/HomeViewModel.swift
+++ b/Nippardation/Home/HomeViewModel.swift
@@ -10,15 +10,6 @@ import Combine
 
 @MainActor
 final class HomeViewModel: ObservableObject {
-    // Legacy workout templates (kept for backward compatibility)
-    @Published var workouts: [Workout] = [
-        upperStrength,
-        lowerStrength,
-        pullDay,
-        pushDay,
-        legDay
-    ]
-
     // Active program data
     @Published var activeProgram: Program?
     @Published var nextWorkout: ProgramWorkout?
@@ -31,6 +22,8 @@ final class HomeViewModel: ObservableObject {
 
     @Published var isLoading = false
     @Published var error: String?
+    @Published var hasAnyPrograms: Bool?
+    @Published var userTemplates: [Template] = []
 
     private let programRepository: any ProgramRepositoryProtocol
     private let templateRepository: any TemplateRepositoryProtocol
@@ -121,6 +114,25 @@ final class HomeViewModel: ObservableObject {
             }
         }
         weeklyConsistency = weeksWithWorkouts * 25 // out of 100%
+    }
+
+    func checkForPrograms() {
+        Task { @MainActor in
+            do {
+                let programs = try await programRepository.fetchPrograms(forceRefresh: false)
+                self.hasAnyPrograms = !programs.isEmpty
+            } catch {
+                let cached = programRepository.getCachedPrograms()
+                self.hasAnyPrograms = !cached.isEmpty
+            }
+
+            do {
+                let templates = try await templateRepository.fetchTemplates(forceRefresh: false)
+                self.userTemplates = templates
+            } catch {
+                self.userTemplates = templateRepository.getCachedTemplates()
+            }
+        }
     }
 
     func clearError() {

--- a/Nippardation/Home/NoProgramsModalView.swift
+++ b/Nippardation/Home/NoProgramsModalView.swift
@@ -1,0 +1,164 @@
+//
+//  NoProgramsModalView.swift
+//  Nippardation
+//
+//  Modal shown when a user with no programs taps "Start Workout"
+//
+
+import SwiftUI
+
+struct NoProgramsModalView: View {
+    let templates: [Template]
+    let onCreateManually: () -> Void
+    let onGenerateWithAI: () -> Void
+    let onBrowsePrograms: () -> Void
+    let onSelectTemplate: (Template) -> Void
+
+    var body: some View {
+        VStack(spacing: AppSpacing.md) {
+            // Drag indicator
+            Capsule()
+                .fill(Color.secondary.opacity(0.3))
+                .frame(width: 36, height: 5)
+                .padding(.top, AppSpacing.sm)
+
+            if templates.isEmpty {
+                emptyState
+            } else {
+                templateListState
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Empty State (no templates, no programs)
+
+    private var emptyState: some View {
+        VStack(spacing: AppSpacing.lg) {
+            Spacer()
+
+            // Icon
+            ZStack {
+                Circle()
+                    .fill(Color.appTheme.opacity(0.1))
+                    .frame(width: 100, height: 100)
+
+                Image(systemName: "list.bullet.clipboard")
+                    .font(.system(size: 40))
+                    .foregroundColor(.appTheme)
+            }
+
+            // Title & description
+            VStack(spacing: AppSpacing.xs) {
+                Text("Create a Program First")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text("To start a workout, you need at least one program with workout templates. Create or generate one to get started.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, AppSpacing.xl)
+            }
+
+            createProgramButtons
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Template List State (has templates, no programs)
+
+    private var templateListState: some View {
+        VStack(spacing: AppSpacing.sm) {
+            VStack(spacing: AppSpacing.xxs) {
+                Text("No Program Yet")
+                    .font(.title3)
+                    .fontWeight(.bold)
+
+                Text("Start a workout from a saved template, or create a program to organize your training.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, AppSpacing.md)
+            }
+
+            ScrollView {
+                VStack(spacing: AppSpacing.xs) {
+                    ForEach(templates) { template in
+                        Button {
+                            onSelectTemplate(template)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(template.name)
+                                        .font(.body)
+                                        .fontWeight(.medium)
+                                        .lineLimit(1)
+
+                                    Text("\(template.exerciseCount) exercises")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer()
+
+                                Image(systemName: "play.circle.fill")
+                                    .resizable()
+                                    .frame(width: 28, height: 28)
+                            }
+                            .padding(AppSpacing.sm)
+                            .cardStyle()
+                            .contentShape(Rectangle())
+                        }
+                        .tint(Color.appTheme)
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, AppSpacing.md)
+            }
+
+            createProgramButtons
+                .padding(.bottom, AppSpacing.sm)
+        }
+    }
+
+    // MARK: - Shared CTAs
+
+    private var createProgramButtons: some View {
+        VStack(spacing: AppSpacing.sm) {
+            AIGradientButton("Generate with AI") {
+                onGenerateWithAI()
+            }
+            .padding(.horizontal, AppSpacing.xl)
+
+            Button(action: onCreateManually) {
+                HStack {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Create Manually")
+                }
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.horizontal, AppSpacing.xl)
+
+            Button(action: onBrowsePrograms) {
+                Text("Browse Programs")
+                    .font(.subheadline)
+                    .foregroundColor(.appTheme)
+            }
+        }
+    }
+}
+
+#Preview("No Templates") {
+    NoProgramsModalView(
+        templates: [],
+        onCreateManually: {},
+        onGenerateWithAI: {},
+        onBrowsePrograms: {},
+        onSelectTemplate: { _ in }
+    )
+}

--- a/Nippardation/Views/Root/MainTabView.swift
+++ b/Nippardation/Views/Root/MainTabView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainTabView: View {
     @EnvironmentObject private var authManager: AuthManager
     @EnvironmentObject private var deepLinkRouter: DeepLinkRouter
+    @AppStorage("hasCompletedFirstLaunch") private var hasCompletedFirstLaunch = false
     @State private var selectedTab: AppTab = .home
     @State private var showSharePreview = false
 
@@ -56,6 +57,12 @@ struct MainTabView: View {
             }
         }
         .tint(Color.appTheme)
+        .onAppear {
+            if !hasCompletedFirstLaunch {
+                selectedTab = .programs
+                hasCompletedFirstLaunch = true
+            }
+        }
         .environmentBanner()
         .onChange(of: deepLinkRouter.pendingShareToken) { _, token in
             if token != nil {


### PR DESCRIPTION
## Summary
- Removed the 5 hardcoded "Quick Start Workouts" (Pull/Push/Legs/Upper/Lower) from the Start Workout flow in favor of server-backed programs and templates
- New users now land on the Programs tab on first launch, where "Generate with AI" and "Create Manually" CTAs are front and center
- When a user with no programs taps "Start Workout", a half-sheet modal explains they need to create a program, with options to generate with AI, create manually, or browse programs
- If the user has saved templates but no programs, the modal shows a scrollable template list so they can start a workout directly from a template

## Changes
- **WorkoutSelectionView.swift**: Removed `Quick Start Workouts` section and `fallbackWorkouts` property
- **HomeViewModel.swift**: Removed dead `workouts` array; added `hasAnyPrograms` and `userTemplates` state with `checkForPrograms()` method
- **HomeView.swift**: FAB now conditionally shows `NoProgramsModalView` or `WorkoutSelectionView`; added template-to-workout conversion and dismiss-then-present handling
- **NoProgramsModalView.swift** (new): Two-state modal — empty state when no templates, scrollable template list when templates exist
- **MainTabView.swift**: Added `@AppStorage("hasCompletedFirstLaunch")` to route first-launch users to the Programs tab

## Test plan
- [x] Build succeeds
- [x] All unit tests pass
- [ ] Fresh install: app opens to Programs tab (first launch)
- [ ] Subsequent launches: app opens to Home tab
- [ ] User with no programs/templates taps "Start Workout": sees empty-state modal with AI/manual/browse CTAs
- [ ] User with templates but no programs taps "Start Workout": sees scrollable template list in modal
- [ ] Tapping a template in the modal starts a workout and opens ActiveWorkoutView
- [ ] User with programs taps "Start Workout": sees WorkoutSelectionView with active program workouts (no Quick Start section)
- [ ] "Resume Workout" FAB still works for in-progress workouts